### PR TITLE
Update root README with correct install commands and add Japanese version

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,88 @@
+# a11y-specialist-skills
+
+[English](./README.md)
+
+[Claude Code](https://claude.ai/claude-code) 用のアクセシビリティ専門スキルプラグイン。
+
+WCAG 2.2 & WAI-ARIA APG に基づいたアクセシビリティレビューを行うスキルを提供します。
+
+## スキル一覧
+
+| スキル | 説明 |
+|--------|------|
+| [a11y-review](./skills/a11y-review/) | Webページ、コンポーネント実装、デザイン案、仕様書のアクセシビリティレビュー |
+
+## インストール
+
+### プラグインとして（推奨）
+
+```bash
+# マーケットプレイスを追加
+/plugin marketplace add masuP9/a11y-specialist-skills
+
+# プラグインをインストール
+/plugin install a11y-specialist-skills@a11y-specialist-skills
+```
+
+### スタンドアロンスキルとして（シンボリックリンク）
+
+```bash
+# リポジトリをクローン
+git clone https://github.com/masuP9/a11y-specialist-skills.git
+
+# skillsディレクトリにシンボリックリンクを作成
+ln -s /path/to/a11y-specialist-skills/skills/a11y-review ~/.claude/skills/a11y-review
+```
+
+### 開発用
+
+```bash
+# --plugin-dir でローカルテスト
+claude --plugin-dir /path/to/a11y-specialist-skills
+```
+
+## 使い方
+
+Claudeはリクエストに応じて自動的にスキルを検出します：
+
+```
+# 例
+a11yレビューして
+アクセシビリティ確認して
+このページのアクセシビリティをチェックして
+```
+
+特定の対象を指定することもできます：
+
+```
+# URL
+https://example.com のa11yレビューして
+
+# ローカルファイル
+src/components/Button.tsx のアクセシビリティを確認して
+
+# デザイン案
+このデザイン案のa11y観点でレビューして
+```
+
+## レビュー出力
+
+スキルは以下を含む構造化されたフィードバックを提供します：
+
+- **良い点**: アクセシビリティの観点で良くできている点
+- **問題点**: 重要度別に分類された問題（Critical / Major / Minor）
+  - コード/ページ内の箇所
+  - 問題の説明
+  - 関連するWCAG達成基準
+  - 修正案
+- **手動確認**: 人間による確認が必要な項目
+
+## 参考リソース
+
+- [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
+- [WCAG 2.2 日本語訳](https://waic.jp/translations/WCAG22/)
+- [WAI-ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/)
+
+## ライセンス
+
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # a11y-specialist-skills
 
+[日本語版 (Japanese)](./README.ja.md)
+
 Accessibility specialist skills plugin for [Claude Code](https://claude.ai/claude-code).
 
-WCAG 2.2 & WAI-ARIA APG に基づいたアクセシビリティレビューを行うスキルを提供します。
+Provides accessibility review skills based on WCAG 2.2 & WAI-ARIA APG.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| [a11y-review](./skills/a11y-review/) | Webページ、コンポーネント実装、デザイン案、仕様書のアクセシビリティレビュー |
+| [a11y-review](./skills/a11y-review/) | Accessibility review for web pages, component implementations, design mockups, and specifications |
 
 ## Installation
 
 ### As a Plugin (Recommended)
 
 ```bash
-# Add marketplace (if not already added)
-claude marketplace add https://raw.githubusercontent.com/masuP9/a11y-specialist-skills/main/marketplace.json
+# Add marketplace
+/plugin marketplace add masuP9/a11y-specialist-skills
 
 # Install plugin
-claude plugin install a11y-specialist-skills
+/plugin install a11y-specialist-skills@a11y-specialist-skills
 ```
 
 ### As a Standalone Skill (Symlink)
@@ -45,30 +47,29 @@ Claude will automatically detect when to use the skill based on your request:
 
 ```
 # Examples
-a11yレビューして
-アクセシビリティ確認して
-このページのアクセシビリティをチェックして
-Review accessibility of this component
+Review accessibility
+Check a11y
+Accessibility review please
 ```
 
 You can also provide specific targets:
 
 ```
 # URL
-https://example.com のa11yレビューして
+Review a11y for https://example.com
 
 # Local file
-src/components/Button.tsx のアクセシビリティを確認して
+Check accessibility of src/components/Button.tsx
 
 # Design spec
-このデザイン案のa11y観点でレビューして
+Review this design mockup from a11y perspective
 ```
 
 ## Review Output
 
 The skill provides structured feedback including:
 
-- **Good Points**: What's done well from an accessibility perspective
+- **Positive Findings**: What's done well from an accessibility perspective
 - **Issues**: Problems categorized by severity (Critical / Major / Minor)
   - Location in code/page
   - Description of the issue
@@ -79,7 +80,6 @@ The skill provides structured feedback including:
 ## References
 
 - [WCAG 2.2](https://www.w3.org/TR/WCAG22/)
-- [WCAG 2.2 日本語訳](https://waic.jp/translations/WCAG22/)
 - [WAI-ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/)
 
 ## License


### PR DESCRIPTION
## Summary
- Fix installation commands to use correct format:
  - `/plugin marketplace add masuP9/a11y-specialist-skills`
  - `/plugin install a11y-specialist-skills@a11y-specialist-skills`
- Add README.ja.md as Japanese source
- Update README.md to English version with language link

## Test plan
- [ ] Verify install commands work correctly
- [ ] Check language links between README.md and README.ja.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)