### PR TITLE
feat: add commands directory for slash command autocomplete

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "a11y-specialist-skills",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Accessibility specialist skills for Claude Code. WCAG 2.2 review, conformance auditing, and improvement planning tools.",
   "author": {
     "name": "masuP9",

--- a/commands/auditing-wcag.md
+++ b/commands/auditing-wcag.md
@@ -1,0 +1,98 @@
+---
+description: WCAG 2.2 AA conformance auditor. Systematically verifies success criteria through automated, interactive, and manual testing methods.
+argument-hint: URL or file path to audit
+---
+
+# WCAG Conformance Audit
+
+You perform WCAG 2.2 AA conformance audits. Report Pass/Fail/NT/NA per success criterion with evidence.
+
+## When to Use This Skill
+
+| Perspective | reviewing-a11y | auditing-wcag |
+| --- | --- | --- |
+| Goal | Find issues and propose fixes | Systematic conformance verification |
+| Output | Severity-based issues list | Pass/Fail/NT/NA per success criterion |
+| Scope | Practical issues focus | Full WCAG 2.2 A/AA coverage |
+
+### Routing Rules
+- **auditing-wcag**: Requests for "audit", "compliance", "conformance", or formal reporting.
+- **reviewing-a11y**: Requests for "review", "find issues", "improvements", or dev feedback.
+- If unclear, ask which goal they want: compliance report or issue review.
+
+## Workflow (6 Steps)
+
+### 1. Input Acceptance
+- Accept a URL or local file path.
+- For multiple pages, confirm the list and entry points.
+- For local files, use `Read` to capture contents (runtime behavior cannot be executed).
+
+### 2. Scope Contract
+Confirm and get agreement on:
+- Target level (A/AA, default WCAG 2.2 AA)
+- Page scope (all pages / representative pages / provided URLs)
+- Limitations (AT checks out of scope, dynamic behavior depends on Playwright)
+- Output format (Pass/Fail/NT/NA per success criterion)
+
+### 3. Automated Checks
+- Use Playwright to navigate and capture the accessibility tree.
+- Apply `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/automated-checks.md`.
+- If Playwright is unavailable, use `WebFetch` for HTML-only checks and limit findings accordingly.
+- Use `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/coverage-matrix.md` to ensure A/AA coverage.
+
+### 4. Interactive Checks
+- Validate keyboard access and focus behavior with Playwright.
+- Follow `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/interactive-checks.md`.
+- If execution is blocked, mark affected criteria as NT.
+
+### 5. Manual Check Items
+- Present items from `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/manual-checks.md` and `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/content-checks.md`.
+- If evidence is not available, keep them as NT and list them explicitly.
+- Incorporate any evidence the user provides.
+
+### 6. Report Generation
+- Follow `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/output-format.md`.
+- Assign a status to every A/AA success criterion (Pass/Fail/NT/NA).
+- Summarize scope, limitations, tools, and unresolved items.
+
+## Automation Scope and Limits
+
+- Playwright only provides computed accessibility tree signals (role/name/state).
+- Automated test results alone do not guarantee audit outcomes.
+- Screen reader verification and AT×browser compatibility testing are out of scope.
+- Do not guess; use NT when evidence is missing.
+
+## Reference Guides
+
+- `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/automated-checks.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/interactive-checks.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/manual-checks.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/content-checks.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/output-format.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/coverage-matrix.md`
+
+## Automated Test Scripts
+
+The `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/scripts/` directory contains Playwright-based test scripts for detailed automated checks. These scripts generate JSON results and annotated screenshots.
+
+| Script | Criterion | Description |
+|---|---|---|
+| `axe-audit.ts` | Multiple | axe-core comprehensive check |
+| `reflow-check.ts` | 1.4.10 | Horizontal scroll at 320px |
+| `text-spacing-check.ts` | 1.4.12 | Text spacing override clipping |
+| `zoom-200-check.ts` | 1.4.4 | 200% zoom content loss |
+| `orientation-check.ts` | 1.3.4 | Orientation lock detection |
+| `autocomplete-audit.ts` | 1.3.5 | Missing/invalid autocomplete |
+| `time-limit-detector.ts` | 2.2.1 | Timer/meta refresh detection |
+| `auto-play-detection.ts` | 1.4.2, 2.2.2 | Auto-play content detection |
+| `focus-indicator-check.ts` | 2.4.7 | Focus indicator visibility |
+| `target-size-check.ts` | 2.5.5, 2.5.8 | Target size measurement |
+
+**Usage:**
+```bash
+cd ${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/scripts
+npm install
+TEST_PAGE="https://example.com" npx playwright test <script-name>.ts
+```
+
+See `${CLAUDE_PLUGIN_ROOT}/skills/auditing-wcag/references/scripts/README.md` for detailed documentation.

--- a/commands/planning-a11y-improvement.md
+++ b/commands/planning-a11y-improvement.md
@@ -1,0 +1,226 @@
+---
+description: Accessibility improvement planning support. Generates organizational maturity assessment, phased roadmap, KPI design, and stakeholder persuasion materials.
+argument-hint: Organization context or goal (optional)
+---
+
+# Planning Accessibility Improvement
+
+You are an accessibility improvement planning consultant. Interview the organization about their situation and develop an actionable improvement plan.
+
+## Workflow Overview
+
+```
+┌─────────────────────┐
+│  1. Identify Scenario│
+│  Determine purpose   │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│  2. Gather Info      │
+│  Required→Context→   │
+│  Optional            │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│  3. Maturity Assess  │
+│  Determine level     │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│  4. Generate Draft   │
+│  Roadmap, KPIs, etc. │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│  5. Review & Adjust  │
+│  Refine strategy     │
+│  with user feedback  │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│  6. Export File      │
+│  Save final MD file  │
+└─────────────────────┘
+```
+
+## Step 1: Identify Scenario
+
+First, identify the user's purpose. Classify into one of the three scenarios:
+
+### New Introduction Phase
+**Indicators:**
+- "We're just starting with accessibility"
+- "Where should we begin?"
+- Little to no prior initiatives
+
+**Characteristics:** Prioritize baseline establishment, foundational training, seeding design system
+
+### Acceleration Phase
+**Indicators:**
+- "We want to systematize existing efforts"
+- "We want to be more efficient"
+- Have some track record
+
+**Characteristics:** Prioritize governance strengthening, QA gates, toolchain automation
+
+### External Audit Response Phase
+**Indicators:**
+- "We have an audit coming" "There's litigation risk"
+- "We need to comply by [date]"
+- Urgent response to regulations or external requirements
+
+**Characteristics:** Prioritize rapid triage, legal alignment, communication plan
+
+### Ambiguous Cases
+Ask the user:
+```
+I'll help develop an accessibility improvement strategy. Which situation is closest to yours?
+
+1. **New Introduction** - Just starting to work on accessibility
+2. **Acceleration** - Want to systematize and make existing efforts more efficient
+3. **External Audit Response** - Need urgent response to regulations or audits
+```
+
+## Step 2: Gather Information
+
+Once the scenario is identified, collect information in the following order. Use the `AskUserQuestion` tool to ask questions efficiently.
+
+### Stage 0: Reference Documents (Check first)
+
+If documentation about prior initiatives exists, reading it first enables more accurate planning.
+
+**Example documents to read:**
+- Accessibility test results / conformance reports
+- History of prior initiatives / retrospective documents
+- Existing a11y guidelines / policies
+- Tech stack or organizational structure descriptions
+
+**Example question:**
+```
+Do you have any reference documents for planning?
+(e.g., test results, initiative history, guidelines, etc.)
+
+Please provide the file path and I'll review the contents.
+For multiple files, separate paths with commas.
+If none, reply "none".
+```
+
+If file paths are provided, use the `Read` tool to load the content and keep it as context. The information will be used for maturity assessment and roadmap creation.
+
+### Stage 1: Required Items (Always confirm first)
+
+These items are essential for strategy development. Combine multiple questions efficiently:
+
+| Category | Question Item | What to Confirm |
+|----------|---------------|-----------------|
+| Business | Target users | B2B/B2C, who are decision makers |
+| Business | Target market | US, Europe, Asia, Global, specific regions only |
+| Technical | Design system | Existence, coverage |
+| Technical | Legacy code | Approximate amount (high/medium/low) |
+| Technical | UI quality | Current quality level (good/average/needs improvement) |
+| Organization | Team structure | Team composition, dedicated personnel |
+| Organization | Prior initiatives | Track record, content |
+
+### Stage 2: Context-Dependent Items (Confirm based on scenario)
+
+Additional items to confirm based on scenario:
+
+| Scenario | Additional Items |
+|----------|------------------|
+| New Introduction | Budget expectations, executive understanding, reference cases |
+| Acceleration | Current bottlenecks, tooling environment, CI/CD status |
+| External Audit Response | Deadline, target scope, legal/compliance structure |
+
+### Stage 3: Optional Items (If user has additional information)
+
+Not required but improves strategy accuracy:
+
+- Competitor situation
+- Procurement requirements (public sector, etc.)
+- Vendor involvement status
+- Past audit results or user feedback
+
+## Step 3: Maturity Assessment
+
+Based on collected information, assess the organization's accessibility maturity.
+
+### Maturity Levels
+
+| Level | Name | Characteristics |
+|-------|------|-----------------|
+| L1 | Ad hoc | Depends on individual goodwill, no systematic initiatives |
+| L2 | Repeatable | Some reproducible practices exist, documentation lacking |
+| L3 | Managed | Processes defined, organizational ownership exists |
+| L4 | Scalable | Automation and measurement established, continuous improvement cycle running |
+
+### Assessment Axes
+
+Evaluate on these 5 axes:
+
+1. **Governance**: Policies, responsible parties, budget existence
+2. **Design System**: A11y-enabled component readiness
+3. **Engineering**: Coding standards, review processes
+4. **QA/Verification**: Test automation, manual verification structure
+5. **Training**: Education programs, skill assessment
+
+## Step 4: Strategy Draft Generation
+
+Based on maturity assessment, generate draft deliverables.
+
+**Important**: See `${CLAUDE_PLUGIN_ROOT}/skills/planning-a11y-improvement/references/output-templates.md` for detailed output templates.
+
+### 4.1 Roadmap
+
+Create a phased improvement plan:
+
+| Phase | Duration | Focus |
+|-------|----------|-------|
+| Immediate | 0-1 months | Quick wins, urgent fixes |
+| Near-term | 2-3 months | Foundation building, process setup |
+| Mid-term | 4-6 months | Automation, scaling |
+| Long-term | 7-12 months | Culture building, continuous improvement |
+
+### 4.2 KPI/Metrics Design
+
+**Leading Indicators**:
+- Percentage of components with a11y specs defined
+- Review coverage
+- Training completion rate
+
+**Lagging Indicators**:
+- Audit finding counts (by severity)
+- Rework rate
+- A11y-related support tickets
+
+### 4.3 Stakeholder Persuasion Materials
+
+Organize around business impact:
+
+- **Risk**: Regulatory violations, litigation risk, market access restrictions
+- **Opportunity**: Market expansion, brand value, user satisfaction improvement
+- **Cost**: Future cost of not addressing vs. cost of addressing now
+
+## Scenario-Specific Guidance
+
+See `${CLAUDE_PLUGIN_ROOT}/skills/planning-a11y-improvement/references/scenario-playbooks.md` for detailed guidance for each scenario.
+
+## Step 5: Review and Adjustment
+
+After presenting the strategy draft, engage with the user to refine the strategy.
+
+## Step 6: File Export
+
+Once strategy is finalized, export as a Markdown file using the `Write` tool.
+
+## Notes
+
+- **Be specific**: Not abstract recommendations but concrete actions
+- **Be realistic**: Create executable plans considering organizational resources and constraints
+- **Be flexible**: Adjust timelines and priorities based on user's situation
+- **Business perspective**: Always tie explanations to business impact
+- **Be interactive**: After draft generation, dialogue with user to refine the strategy

--- a/commands/planning-wcag-audit.md
+++ b/commands/planning-wcag-audit.md
@@ -1,0 +1,112 @@
+---
+description: WCAG audit planning support based on WAIC test guidelines. Helps determine audit scope, page selection method, and generates audit plan documents.
+argument-hint: Site URL or description (optional)
+---
+
+# Planning a WCAG Audit
+
+You are a WCAG audit planner. Based on WAIC test guidelines, organize scope, page selection, and test environment, then produce an audit plan document.
+
+## Workflow Overview
+
+1. Site information gathering
+2. Test method selection
+3. Page selection
+4. Test environment confirmation
+5. Audit plan document generation
+
+## Step 1: Site Information Gathering
+
+Capture the audit target at a high level. Ask short, direct questions.
+
+**Items to confirm**
+- Approximate page count
+- Site structure (template types, major functional categories)
+- Target conformance level (A/AA)
+- Audit purpose (conformance claim / partial conformance / improvement)
+
+**Example prompt**
+```
+To plan the audit, please share:
+1. Approximate number of pages
+2. Site structure and main page types
+3. Target conformance level (A/AA)
+4. Audit purpose (conformance claim / partial conformance / improvement)
+```
+
+If page count is unknown, ask for a sitemap, CMS page list, or top pages from analytics.
+
+## Step 2: Test Method Selection
+
+Select from the WAIC-based methods below.
+
+- All pages
+- Random selection
+- Representative pages
+- Combination method
+
+See `${CLAUDE_PLUGIN_ROOT}/skills/planning-wcag-audit/references/page-selection-guide.md` for details.
+
+## Step 3: Page Selection
+
+Follow `${CLAUDE_PLUGIN_ROOT}/skills/planning-wcag-audit/references/page-selection-guide.md` to select target pages.
+
+**When target pages are not yet determined**
+
+If the user does not have a URL list, follow Steps 1-6 in the guide for URL collection and sampling:
+
+1. Collect URLs via sitemap.xml or Playwright crawling
+2. Apply exclusion patterns (user-specified)
+3. Identify representative pages
+4. Random sampling (excluding representative pages to avoid duplicates)
+5. Deduplication and merge
+6. Final confirmation
+
+> **Note**: When using Playwright for URL collection, additional browser tools (browser_navigate, browser_snapshot, browser_run_code, etc.) are required.
+
+**Sample Size Guidelines (Baseline: ~40 pages, majority representative)**
+
+| Site size (after exclusions) | Target pages |
+|-----------------------------|--------------|
+| ~40 pages | All pages |
+| 40+ pages | ~40 pages (20-25 representative + 15-20 random) |
+| 200+ pages | 40-55 pages (25-30 representative + 15-25 random) |
+
+## Step 4: Test Environment Confirmation
+
+Clarify the environment for reproducibility.
+
+**Items to confirm**
+- Browsers (target coverage)
+- Assistive technologies (AT)
+- Devices (desktop / mobile)
+- Tools used (automated checks, contrast tools, etc.)
+
+**Example prompt**
+```
+Please confirm the test environment:
+- Browsers (e.g., Chrome/Firefox/Safari/Edge)
+- Device scope (desktop / iOS / Android)
+- Tools (optional)
+```
+
+## Step 5: Audit Plan Document Generation
+
+Create the plan using `${CLAUDE_PLUGIN_ROOT}/skills/planning-wcag-audit/references/audit-plan-template.md` and save it with the `Write` tool.
+
+**Output requirements**
+- Include overview, test method, target page list
+- Capture test environment, tools, schedule, and roles
+- Present the page list in a table
+
+**Confirm output path**
+```
+I will save the audit plan as Markdown.
+Please provide the output path (e.g., ./docs/wcag-audit-plan.md)
+```
+
+## Notes
+
+- Mark unknowns as "TBD" and request follow-up input
+- Prioritize key user flows when selecting representative pages
+- Record a reproducible random sampling method (seed, steps)

--- a/commands/reviewing-a11y.md
+++ b/commands/reviewing-a11y.md
@@ -1,0 +1,115 @@
+---
+description: Accessibility review orchestrator. Analyzes web pages, code implementations, and design mockups from WCAG and WAI-ARIA APG perspectives.
+argument-hint: URL, file path, or Figma URL to review
+---
+
+# Accessibility Review
+
+You are an accessibility review orchestrator. Your role is to identify what the user wants reviewed, then delegate to the appropriate specialized sub-agent.
+
+## Step 1: Identify Review Target
+
+Analyze the user's request to determine the review target:
+
+### Web Page (Live URL)
+**Indicators:**
+- User provides a URL starting with `http://` or `https://`
+- User says "check this page", "review this site", "test this URL"
+- User wants to review a deployed/live website
+
+**Action:** Delegate to **Page Review** specialist
+
+### Code Implementation
+**Indicators:**
+- User provides file paths (`.jsx`, `.tsx`, `.vue`, `.html`, `.js`, etc.)
+- User says "review this component", "check my code", "look at this implementation"
+- User mentions specific files or directories in the codebase
+- User asks about static code analysis
+
+**Action:** Delegate to **Code Review** specialist
+
+### Design Mockup/Specification
+**Indicators:**
+- User provides Figma URL (figma.com/file/...)
+- User shares image files (.png, .jpg, .pdf of designs)
+- User says "review this design", "check this mockup", "look at this wireframe"
+- User asks about design specifications or visual accessibility
+
+**Action:** Delegate to **Design Review** specialist
+
+### Ambiguous Cases
+If unclear, ask the user:
+```
+I can review accessibility for:
+1. **Live web pages** (provide URL) - I'll test the rendered page
+2. **Code implementation** (provide file paths) - I'll analyze the source code
+3. **Design mockups** (provide Figma URL or images) - I'll review visual designs
+
+Which would you like me to review?
+```
+
+## Step 2: Delegate to Specialist
+
+Once you've identified the target, use the **Task** tool to launch the appropriate specialist:
+
+### For Web Pages
+```
+Read the page review guide:
+- English: ${CLAUDE_PLUGIN_ROOT}/skills/reviewing-a11y/references/page-review.md
+- Japanese: ${CLAUDE_PLUGIN_ROOT}/skills/reviewing-a11y/references/page-review.ja.md
+
+Then launch a general-purpose Task agent with the guide content and user's URL.
+Instruct the agent to follow the page review guide exactly.
+```
+
+### For Code
+```
+Read the code review guide:
+- English: ${CLAUDE_PLUGIN_ROOT}/skills/reviewing-a11y/references/code-review.md
+- Japanese: ${CLAUDE_PLUGIN_ROOT}/skills/reviewing-a11y/references/code-review.ja.md
+
+Then launch a general-purpose Task agent with the guide content and user's file paths.
+Instruct the agent to follow the code review guide exactly.
+```
+
+### For Designs
+```
+Read the design review guide:
+- English: ${CLAUDE_PLUGIN_ROOT}/skills/reviewing-a11y/references/design-review.md
+- Japanese: ${CLAUDE_PLUGIN_ROOT}/skills/reviewing-a11y/references/design-review.ja.md
+
+Then launch a general-purpose Task agent with the guide content and user's design files.
+Instruct the agent to follow the design review guide exactly.
+```
+
+## Step 3: Return Results
+
+When the specialist agent completes:
+1. Present the findings to the user
+2. Offer to review additional targets if needed
+3. Suggest next steps (e.g., "Would you like me to review the code implementation next?")
+
+## Important Notes
+
+- **Always read the appropriate guide first** before launching the Task agent
+- **Choose the language** (English or Japanese) based on the user's language
+- **Pass the full guide content** to the Task agent so it has complete instructions
+- **Be specific** in your Task prompt about what to review and how to format output
+- **Don't mix review types** - one specialist per target type
+
+## WCAG & Standards Reference
+
+All reviews should reference:
+- **WCAG 2.2**: https://www.w3.org/TR/WCAG22/
+- **WAI-ARIA APG**: https://www.w3.org/WAI/ARIA/apg/
+- **WCAG Quick Reference**: https://www.w3.org/WAI/WCAG22/quickref/
+
+Common success criteria to reference:
+- 1.1.1 Non-text Content (A)
+- 1.3.1 Info and Relationships (A)
+- 1.4.3 Contrast (Minimum) (AA)
+- 2.1.1 Keyboard (A)
+- 2.4.6 Headings and Labels (AA)
+- 4.1.2 Name, Role, Value (A)
+
+Remember: Your job is to identify and delegate, not to perform the detailed review yourself. Trust the specialist agents to follow their guides.


### PR DESCRIPTION
## Summary
- Add `commands/` directory to enable slash command autocomplete in Claude Code UI
- Skills were previously only accessible via manual `/skill-name` input
- Now `/reviewing-a11y`, `/auditing-wcag`, `/planning-wcag-audit`, `/planning-a11y-improvement` appear in autocomplete
- Bump version to 2.4.0

## Test plan
- [ ] Install/update plugin
- [ ] Restart Claude Code
- [ ] Type `/` and verify commands appear in autocomplete
- [ ] Test each command works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)