### PR TITLE
fix: add name field to command frontmatter for slash command recognition

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "a11y-specialist-skills",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Accessibility specialist skills for Claude Code. WCAG 2.2 review, conformance auditing, and improvement planning tools.",
   "author": {
     "name": "masuP9",

--- a/commands/auditing-wcag.md
+++ b/commands/auditing-wcag.md
@@ -1,4 +1,5 @@
 ---
+name: auditing-wcag
 description: WCAG 2.2 AA conformance auditor. Systematically verifies success criteria through automated, interactive, and manual testing methods.
 argument-hint: URL or file path to audit
 ---

--- a/commands/planning-a11y-improvement.md
+++ b/commands/planning-a11y-improvement.md
@@ -1,4 +1,5 @@
 ---
+name: planning-a11y-improvement
 description: Accessibility improvement planning support. Generates organizational maturity assessment, phased roadmap, KPI design, and stakeholder persuasion materials.
 argument-hint: Organization context or goal (optional)
 ---

--- a/commands/planning-wcag-audit.md
+++ b/commands/planning-wcag-audit.md
@@ -1,4 +1,5 @@
 ---
+name: planning-wcag-audit
 description: WCAG audit planning support based on WAIC test guidelines. Helps determine audit scope, page selection method, and generates audit plan documents.
 argument-hint: Site URL or description (optional)
 ---

--- a/commands/reviewing-a11y.md
+++ b/commands/reviewing-a11y.md
@@ -1,4 +1,5 @@
 ---
+name: reviewing-a11y
 description: Accessibility review orchestrator. Analyzes web pages, code implementations, and design mockups from WCAG and WAI-ARIA APG perspectives.
 argument-hint: URL, file path, or Figma URL to review
 ---


### PR DESCRIPTION
## Summary
- Add `name` field to all command frontmatter files
- Without `name` field, commands were not recognized as standalone slash commands
- Now `/reviewing-a11y`, `/auditing-wcag`, etc. work without plugin namespace prefix
- Bump version to 2.5.0

## Changes
- `commands/reviewing-a11y.md` - add `name: reviewing-a11y`
- `commands/auditing-wcag.md` - add `name: auditing-wcag`
- `commands/planning-wcag-audit.md` - add `name: planning-wcag-audit`
- `commands/planning-a11y-improvement.md` - add `name: planning-a11y-improvement`

## Test plan
- [ ] Update plugin: `claude plugin update "a11y-specialist-skills@a11y-specialist-skills"`
- [ ] Restart Claude Code
- [ ] Type `/reviewing-a11y` (without plugin prefix) and verify it works
- [ ] Check autocomplete shows commands without plugin prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)