### PR TITLE
feat(a11y-audit): monorepo + @a11y-skills/audit npm package (Block A, 0.1.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: skills/auditing-wcag/references/scripts
 
       - name: Type-check & build
-        run: npm run build --workspace @masup9/a11y-audit
+        run: npm run build --workspace @a11y-skills/audit
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
@@ -51,10 +51,10 @@ jobs:
         working-directory: skills/auditing-wcag/references/scripts
 
       - name: Run smoke + parity tests
-        run: npm test --workspace @masup9/a11y-audit
+        run: npm test --workspace @a11y-skills/audit
 
       - name: Verify publish payload
-        run: npm publish --workspace @masup9/a11y-audit --dry-run
+        run: npm publish --workspace @a11y-skills/audit --dry-run
 
   wcag-audit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,49 @@ on:
     branches: [main, master]
     paths:
       - 'skills/auditing-wcag/references/scripts/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'tsconfig.base.json'
       - '.github/workflows/ci.yml'
   pull_request:
     branches: [main, master]
     paths:
       - 'skills/auditing-wcag/references/scripts/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'tsconfig.base.json'
       - '.github/workflows/ci.yml'
   workflow_dispatch:
 
 jobs:
+  a11y-audit-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check & build
+        run: npm run build --workspace @masup9/a11y-audit
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: packages/a11y-audit
+
+      - name: Run smoke tests
+        run: npm test --workspace @masup9/a11y-audit
+
+      - name: Verify publish payload
+        run: npm publish --workspace @masup9/a11y-audit --dry-run
+
   wcag-audit-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install skill script deps (for parity drift guard)
+        run: npm ci
+        working-directory: skills/auditing-wcag/references/scripts
+
       - name: Type-check & build
         run: npm run build --workspace @masup9/a11y-audit
 
@@ -42,7 +46,11 @@ jobs:
         run: npx playwright install --with-deps chromium
         working-directory: packages/a11y-audit
 
-      - name: Run smoke tests
+      - name: Install Playwright browsers (skill, for parity)
+        run: npx playwright install chromium
+        working-directory: skills/auditing-wcag/references/scripts
+
+      - name: Run smoke + parity tests
         run: npm test --workspace @masup9/a11y-audit
 
       - name: Verify publish payload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release a11y-audit
 
-# Publishes @masup9/a11y-audit to npm when a tag like `a11y-audit-v0.1.0` is
+# Publishes @a11y-skills/audit to npm when a tag like `a11y-audit-v0.1.0` is
 # pushed. Requires an `NPM_TOKEN` repository secret with publish rights.
 on:
   push:
@@ -27,11 +27,11 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npm run build --workspace @masup9/a11y-audit
+        run: npm run build --workspace @a11y-skills/audit
 
       - name: Publish (dry-run on workflow_dispatch)
         if: github.event_name == 'workflow_dispatch'
-        run: npm publish --workspace @masup9/a11y-audit --access public --dry-run
+        run: npm publish --workspace @a11y-skills/audit --access public --dry-run
 
       # Idempotent: skip publishing a version that is already on npm (e.g. when
       # a tag is pushed for a version that was published manually).
@@ -39,15 +39,15 @@ jobs:
         id: published
         run: |
           VERSION=$(node -p "require('./packages/a11y-audit/package.json').version")
-          if npm view "@masup9/a11y-audit@$VERSION" version >/dev/null 2>&1; then
+          if npm view "@a11y-skills/audit@$VERSION" version >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "@masup9/a11y-audit@$VERSION is already published; skipping publish."
+            echo "@a11y-skills/audit@$VERSION is already published; skipping publish."
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to npm
         if: github.event_name == 'push' && steps.published.outputs.exists != 'true'
-        run: npm publish --workspace @masup9/a11y-audit --access public --provenance
+        run: npm publish --workspace @a11y-skills/audit --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,21 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: npm publish --workspace @masup9/a11y-audit --access public --dry-run
 
+      # Idempotent: skip publishing a version that is already on npm (e.g. when
+      # a tag is pushed for a version that was published manually).
+      - name: Check if version already published
+        id: published
+        run: |
+          VERSION=$(node -p "require('./packages/a11y-audit/package.json').version")
+          if npm view "@masup9/a11y-audit@$VERSION" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "@masup9/a11y-audit@$VERSION is already published; skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && steps.published.outputs.exists != 'true'
         run: npm publish --workspace @masup9/a11y-audit --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release a11y-audit
+
+# Publishes @masup9/a11y-audit to npm when a tag like `a11y-audit-v0.1.0` is
+# pushed. Requires an `NPM_TOKEN` repository secret with publish rights.
+on:
+  push:
+    tags:
+      - 'a11y-audit-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build --workspace @masup9/a11y-audit
+
+      - name: Publish (dry-run on workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: npm publish --workspace @masup9/a11y-audit --access public --dry-run
+
+      - name: Publish to npm
+        if: github.event_name == 'push'
+        run: npm publish --workspace @masup9/a11y-audit --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .codex-pane-id
 collab.sock
 
+# Local planning doc (kept out of version control)
+PLAN-npm-publish.md
+
 # Build output
 dist/
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,14 @@
 .codex-pane-id
 collab.sock
 
+# Build output
+dist/
+
 # Scripts output
 node_modules/
 test-results/
+playwright-report/
+*.tsbuildinfo
 focus-indicators.png
 auto-play-screenshots/
 reflow-result.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,155 @@
+{
+  "name": "a11y-specialist-skills-monorepo",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "a11y-specialist-skills-monorepo",
+      "version": "0.0.0",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ]
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@masup9/a11y-audit": {
+      "resolved": "packages/a11y-audit",
+      "link": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/a11y-audit": {
+      "name": "@masup9/a11y-audit",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.10.0",
+        "@playwright/test": "^1.50.0",
+        "@types/node": "^22.10.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@axe-core/playwright": "^4.10.0",
+        "@playwright/test": "^1.50.0"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,10 @@
         "packages/*"
       ]
     },
+    "node_modules/@a11y-skills/audit": {
+      "resolved": "packages/a11y-audit",
+      "link": true
+    },
     "node_modules/@axe-core/playwright": {
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
@@ -24,10 +28,6 @@
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
       }
-    },
-    "node_modules/@masup9/a11y-audit": {
-      "resolved": "packages/a11y-audit",
-      "link": true
     },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
@@ -134,7 +134,7 @@
       "license": "MIT"
     },
     "packages/a11y-audit": {
-      "name": "@masup9/a11y-audit",
+      "name": "@a11y-skills/audit",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "a11y-specialist-skills-monorepo",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Monorepo for a11y-specialist-skills: Claude Code skill plugin + @masup9/a11y-audit npm package",
+  "license": "MIT",
+  "author": {
+    "name": "masuP9",
+    "url": "https://github.com/masuP9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/masuP9/a11y-specialist-skills"
+  },
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present",
+    "typecheck": "npm run typecheck --workspaces --if-present",
+    "clean": "npm run clean --workspaces --if-present"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "a11y-specialist-skills-monorepo",
   "private": true,
   "version": "0.0.0",
-  "description": "Monorepo for a11y-specialist-skills: Claude Code skill plugin + @masup9/a11y-audit npm package",
+  "description": "Monorepo for a11y-specialist-skills: Claude Code skill plugin + @a11y-skills/audit npm package",
   "license": "MIT",
   "author": {
     "name": "masuP9",

--- a/packages/a11y-audit/CHANGELOG.md
+++ b/packages/a11y-audit/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to `@masup9/a11y-audit` are documented here. This project
+adheres to [Semantic Versioning](https://semver.org/).
+
+## 0.1.0
+
+Initial preview release. The function API may change before `1.0.0` based on
+downstream feedback.
+
+### Added
+
+- `runAxeAudit` — axe-core broad WCAG coverage (2.0/2.1/2.2 A & AA).
+- `runFocusIndicatorCheck` — WCAG 2.4.7 / 2.4.12 / 3.2.1 (owns its browser
+  context; supports `contextOptions`).
+- `runReflowCheck` — WCAG 1.4.10.
+- `runTargetSizeCheck` — WCAG 2.5.5 / 2.5.8.
+- Compatibility `test-entries/*` for use with Playwright `testMatch`
+  (`TEST_PAGE` / `A11Y_OUTPUT_DIR`).
+- `schemas` subpath: result types + hand-written JSON Schemas.
+- Output path resolution: `outputDir` option → `A11Y_OUTPUT_DIR` env →
+  `process.cwd()`, with `outputPath`/`outputDir` exclusivity (promoted from
+  the downstream `resolveOutputPath` improvement).
+
+### Notes
+
+- Ported from the `auditing-wcag` skill's vendor scripts, including the
+  downstream strict-TS fix in the focus check.
+- Screenshots default to `false` in the function API; the compatibility entries
+  enable them to preserve legacy behavior.
+- Phase 2 checks (text-spacing / zoom-200 / orientation / autocomplete /
+  time-limit / auto-play) are out of scope for this release.

--- a/packages/a11y-audit/CHANGELOG.md
+++ b/packages/a11y-audit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `@masup9/a11y-audit` are documented here. This project
+All notable changes to `@a11y-skills/audit` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
 ## 0.1.0

--- a/packages/a11y-audit/CHANGELOG.md
+++ b/packages/a11y-audit/CHANGELOG.md
@@ -15,8 +15,10 @@ downstream feedback.
   context; supports `contextOptions`).
 - `runReflowCheck` — WCAG 1.4.10.
 - `runTargetSizeCheck` — WCAG 2.5.5 / 2.5.8.
-- Compatibility `test-entries/*` for use with Playwright `testMatch`
-  (`TEST_PAGE` / `A11Y_OUTPUT_DIR`).
+- Compatibility `test-entries/*`, run via a one-line local re-export spec
+  (`TEST_PAGE` / `A11Y_OUTPUT_DIR`). Note: Playwright excludes `node_modules`
+  from test collection, so a `testMatch` glob into `node_modules` finds no
+  tests — use the re-export spec instead.
 - `schemas` subpath: result types + hand-written JSON Schemas.
 - Output path resolution: `outputDir` option → `A11Y_OUTPUT_DIR` env →
   `process.cwd()`, with `outputPath`/`outputDir` exclusivity (promoted from

--- a/packages/a11y-audit/README.ja.md
+++ b/packages/a11y-audit/README.ja.md
@@ -1,4 +1,4 @@
-# @masup9/a11y-audit
+# @a11y-skills/audit
 
 Playwright + axe-core ベースの WCAG 2.2 アクセシビリティ検査関数。
 
@@ -23,7 +23,7 @@ Claude Code skill から機能本体を切り出したものです。4 つの検
 ## インストール
 
 ```sh
-npm install -D @masup9/a11y-audit @playwright/test @axe-core/playwright
+npm install -D @a11y-skills/audit @playwright/test @axe-core/playwright
 ```
 
 `@playwright/test` と `@axe-core/playwright` は **peer dependencies** です。
@@ -38,7 +38,7 @@ return を担います。
 
 ```ts
 import { test } from "@playwright/test";
-import { runAxeAudit } from "@masup9/a11y-audit/playwright";
+import { runAxeAudit } from "@a11y-skills/audit/playwright";
 
 test("axe audit", async ({ page }, testInfo) => {
   await page.goto("https://example.com");
@@ -57,7 +57,7 @@ test("axe audit", async ({ page }, testInfo) => {
 を受け取ります。
 
 ```ts
-import { runFocusIndicatorCheck } from "@masup9/a11y-audit/playwright";
+import { runFocusIndicatorCheck } from "@a11y-skills/audit/playwright";
 
 test("focus indicators", async ({ browser }, testInfo) => {
   const result = await runFocusIndicatorCheck({
@@ -95,13 +95,13 @@ entry は import 時に `test(...)` を呼び、`TEST_PAGE`（対象 URL）と `
 
 ```ts
 // tests/a11y/axe.spec.ts
-import "@masup9/a11y-audit/test-entries/axe-audit";
+import "@a11y-skills/audit/test-entries/axe-audit";
 // tests/a11y/focus.spec.ts
-import "@masup9/a11y-audit/test-entries/focus-indicator-check";
+import "@a11y-skills/audit/test-entries/focus-indicator-check";
 // tests/a11y/reflow.spec.ts
-import "@masup9/a11y-audit/test-entries/reflow-check";
+import "@a11y-skills/audit/test-entries/reflow-check";
 // tests/a11y/target-size.spec.ts
-import "@masup9/a11y-audit/test-entries/target-size-check";
+import "@a11y-skills/audit/test-entries/target-size-check";
 ```
 
 ```sh
@@ -109,15 +109,15 @@ TEST_PAGE=https://example.com A11Y_OUTPUT_DIR=./a11y-results npx playwright test
 ```
 
 > **`node_modules` への `testMatch` が使えない理由.** Playwright はテスト収集から
-> `node_modules` を除外するため、`**/node_modules/@masup9/a11y-audit/dist/test-entries/*.js`
+> `node_modules` を除外するため、`**/node_modules/@a11y-skills/audit/dist/test-entries/*.js`
 > を `testMatch` に指定してもテストは見つかりません。上記の 1 行 re-export spec が
 > entry を実行する正式な方法です。
 
 ## 結果型とスキーマ
 
 ```ts
-import type { AxeAuditResult, FocusCheckResult } from "@masup9/a11y-audit/schemas";
-import { RESULT_SCHEMAS } from "@masup9/a11y-audit/schemas";
+import type { AxeAuditResult, FocusCheckResult } from "@a11y-skills/audit/schemas";
+import { RESULT_SCHEMAS } from "@a11y-skills/audit/schemas";
 ```
 
 `RESULT_SCHEMAS` は各検査 id に手書きの JSON Schema を対応付けており、`*-result.json`

--- a/packages/a11y-audit/README.ja.md
+++ b/packages/a11y-audit/README.ja.md
@@ -82,6 +82,11 @@ test("focus indicators", async ({ browser }, testInfo) => {
 スクリーンショット（有効時）は結果ファイルの隣に書き出します。`outputFile` はファイル名のみ
 指定可能です。絶対パスを使う場合は `outputPath` を使ってください。
 
+> **リフローの注意.** `runReflowCheck` は自身で狭い viewport を設定するため、遷移済みの
+> page でも動作します。load 時にのみ viewport を読むページでは、legacy スクリプトと完全に
+> 同じ結果を得るために `page.goto(...)` の**前**に viewport を設定してください（互換 entry
+> はこれを行っています）。
+
 ## 使い方 — 互換 test entry
 
 テスト本体を書きたくない場合は、同梱 entry を 1 行のローカル spec から re-export します。

--- a/packages/a11y-audit/README.ja.md
+++ b/packages/a11y-audit/README.ja.md
@@ -84,29 +84,29 @@ test("focus indicators", async ({ browser }, testInfo) => {
 
 ## 使い方 — 互換 test entry
 
-テストファイルを書きたくない場合は、Playwright の `testMatch` を同梱 entry に向けます。
-`TEST_PAGE`（対象 URL）と `A11Y_OUTPUT_DIR`（出力先）を読み、スクリーンショットも撮る、
-従来スクリプトと同等の挙動です。
+テスト本体を書きたくない場合は、同梱 entry を 1 行のローカル spec から re-export します。
+entry は import 時に `test(...)` を呼び、`TEST_PAGE`（対象 URL）と `A11Y_OUTPUT_DIR`
+（出力先）を読み、スクリーンショットも撮ります（従来スクリプトと同等の挙動）。
 
 ```ts
-// playwright.config.ts
-import { defineConfig } from "@playwright/test";
-
-export default defineConfig({
-  testMatch: ["**/node_modules/@masup9/a11y-audit/dist/test-entries/*.js"],
-});
+// tests/a11y/axe.spec.ts
+import "@masup9/a11y-audit/test-entries/axe-audit";
+// tests/a11y/focus.spec.ts
+import "@masup9/a11y-audit/test-entries/focus-indicator-check";
+// tests/a11y/reflow.spec.ts
+import "@masup9/a11y-audit/test-entries/reflow-check";
+// tests/a11y/target-size.spec.ts
+import "@masup9/a11y-audit/test-entries/target-size-check";
 ```
 
 ```sh
 TEST_PAGE=https://example.com A11Y_OUTPUT_DIR=./a11y-results npx playwright test
 ```
 
-`node_modules` への `testMatch` が扱いにくい場合は、1 行のローカル spec を置く方法もあります。
-
-```ts
-// tests/a11y/axe.spec.ts
-import "@masup9/a11y-audit/test-entries/axe-audit";
-```
+> **`node_modules` への `testMatch` が使えない理由.** Playwright はテスト収集から
+> `node_modules` を除外するため、`**/node_modules/@masup9/a11y-audit/dist/test-entries/*.js`
+> を `testMatch` に指定してもテストは見つかりません。上記の 1 行 re-export spec が
+> entry を実行する正式な方法です。
 
 ## 結果型とスキーマ
 

--- a/packages/a11y-audit/README.ja.md
+++ b/packages/a11y-audit/README.ja.md
@@ -1,0 +1,123 @@
+# @masup9/a11y-audit
+
+Playwright + axe-core ベースの WCAG 2.2 アクセシビリティ検査関数。
+
+本パッケージは [`auditing-wcag`](https://github.com/masuP9/a11y-specialist-skills)
+Claude Code skill から機能本体を切り出したものです。4 つの検査を関数として提供し、
+すぐ実行できる Playwright 用の互換 test entry も同梱します。
+
+> **English: see [README.md](./README.md).**
+
+> **スコープ.** 自動テストで検出できるのは WCAG 違反の約 30〜40% です。完全な準拠確認には
+> 手動テストが必須です。本パッケージはその一部を自動化します。
+
+## 検査一覧 (v0.1.0)
+
+| 関数 | WCAG |
+| --- | --- |
+| `runAxeAudit` | axe-core による広範な検出 (2.0/2.1/2.2 A & AA) |
+| `runFocusIndicatorCheck` | 2.4.7 フォーカスの可視化 / 2.4.12 フォーカスの非遮蔽 / 3.2.1 オンフォーカス |
+| `runReflowCheck` | 1.4.10 リフロー |
+| `runTargetSizeCheck` | 2.5.5 / 2.5.8 ターゲットのサイズ |
+
+## インストール
+
+```sh
+npm install -D @masup9/a11y-audit @playwright/test @axe-core/playwright
+```
+
+`@playwright/test` と `@axe-core/playwright` は **peer dependencies** です。
+
+> ESM 専用です。CommonJS ビルドは同梱しません。ESM（または ESM 出力の TypeScript）から
+> import してください。
+
+## 使い方 — 関数 API（推奨）
+
+ページの遷移は呼び出し側で行い、関数は検査の実行・結果 JSON の書き出し・結果オブジェクトの
+return を担います。
+
+```ts
+import { test } from "@playwright/test";
+import { runAxeAudit } from "@masup9/a11y-audit/playwright";
+
+test("axe audit", async ({ page }, testInfo) => {
+  await page.goto("https://example.com");
+  const result = await runAxeAudit({
+    page,
+    outputDir: testInfo.outputDir,   // axe-result.json の出力先
+    // outputFile: "axe-result.json", // 任意で上書き
+    // tags: ["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"],
+  });
+  expect(result.violationCount).toBe(0);
+});
+```
+
+フォーカス表示検査は、フォーカスで遷移が起きた際に新しい context で再試行するため、
+自身の browser context を所有します。そのため `page` ではなく `browser` と `targetUrl`
+を受け取ります。
+
+```ts
+import { runFocusIndicatorCheck } from "@masup9/a11y-audit/playwright";
+
+test("focus indicators", async ({ browser }, testInfo) => {
+  const result = await runFocusIndicatorCheck({
+    browser,
+    targetUrl: "https://example.com", // または TEST_PAGE 環境変数
+    outputDir: testInfo.outputDir,
+    screenshot: true,                 // 既定: false
+    // contextOptions: { locale: "ja-JP" }, // browser.newContext() に転送
+  });
+  expect(result.elementsWithoutFocusStyle).toBe(0);
+});
+```
+
+### 出力先の解決順
+
+各検査共通:
+
+1. `outputPath` — フルパス（`outputDir`/`outputFile` とは排他）。
+2. それ以外は `outputDir` → `A11Y_OUTPUT_DIR` 環境変数 → `process.cwd()` に、
+   `outputFile` → 各検査の既定ファイル名を結合。
+
+スクリーンショット（有効時）は結果ファイルの隣に書き出します。`outputFile` はファイル名のみ
+指定可能です。絶対パスを使う場合は `outputPath` を使ってください。
+
+## 使い方 — 互換 test entry
+
+テストファイルを書きたくない場合は、Playwright の `testMatch` を同梱 entry に向けます。
+`TEST_PAGE`（対象 URL）と `A11Y_OUTPUT_DIR`（出力先）を読み、スクリーンショットも撮る、
+従来スクリプトと同等の挙動です。
+
+```ts
+// playwright.config.ts
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testMatch: ["**/node_modules/@masup9/a11y-audit/dist/test-entries/*.js"],
+});
+```
+
+```sh
+TEST_PAGE=https://example.com A11Y_OUTPUT_DIR=./a11y-results npx playwright test
+```
+
+`node_modules` への `testMatch` が扱いにくい場合は、1 行のローカル spec を置く方法もあります。
+
+```ts
+// tests/a11y/axe.spec.ts
+import "@masup9/a11y-audit/test-entries/axe-audit";
+```
+
+## 結果型とスキーマ
+
+```ts
+import type { AxeAuditResult, FocusCheckResult } from "@masup9/a11y-audit/schemas";
+import { RESULT_SCHEMAS } from "@masup9/a11y-audit/schemas";
+```
+
+`RESULT_SCHEMAS` は各検査 id に手書きの JSON Schema を対応付けており、`*-result.json`
+を実行時に検証できます。
+
+## ライセンス
+
+MIT

--- a/packages/a11y-audit/README.md
+++ b/packages/a11y-audit/README.md
@@ -83,6 +83,11 @@ For every check:
 Screenshots (when enabled) are written next to the result file. `outputFile`
 must be a bare filename; use `outputPath` for an absolute location.
 
+> **Reflow note.** `runReflowCheck` sets the narrow viewport itself, so it works
+> on an already-navigated page. For pages that read the viewport only at load
+> time, set the viewport *before* `page.goto(...)` for results identical to the
+> legacy script (the compatibility entry does this).
+
 ## Usage — compatibility test entries
 
 If you prefer not to write test bodies, re-export the bundled entries from a

--- a/packages/a11y-audit/README.md
+++ b/packages/a11y-audit/README.md
@@ -1,0 +1,126 @@
+# @masup9/a11y-audit
+
+Playwright + axe-core based WCAG 2.2 accessibility audit functions.
+
+This package is the functional core extracted from the
+[`auditing-wcag`](https://github.com/masuP9/a11y-specialist-skills) Claude Code
+skill. It ships four checks as plain functions plus ready-to-run Playwright
+test entries.
+
+> **日本語版は [README.ja.md](./README.ja.md) を参照してください。**
+
+> **Scope.** Automated testing detects only ~30–40% of WCAG issues. Manual
+> testing is required for full conformance. This package automates a subset.
+
+## Checks (v0.1.0)
+
+| Function | WCAG |
+| --- | --- |
+| `runAxeAudit` | axe-core broad coverage (2.0/2.1/2.2 A & AA) |
+| `runFocusIndicatorCheck` | 2.4.7 Focus Visible / 2.4.12 Focus Not Obscured / 3.2.1 On Focus |
+| `runReflowCheck` | 1.4.10 Reflow |
+| `runTargetSizeCheck` | 2.5.5 / 2.5.8 Target Size |
+
+## Install
+
+```sh
+npm install -D @masup9/a11y-audit @playwright/test @axe-core/playwright
+```
+
+`@playwright/test` and `@axe-core/playwright` are **peer dependencies**.
+
+> ESM only. This package does not ship a CommonJS build; import it from ESM
+> (or a TypeScript project compiled to ESM).
+
+## Usage — function API (recommended)
+
+You navigate the page; the function runs the check, writes a result JSON, and
+returns the parsed result.
+
+```ts
+import { test } from "@playwright/test";
+import { runAxeAudit } from "@masup9/a11y-audit/playwright";
+
+test("axe audit", async ({ page }, testInfo) => {
+  await page.goto("https://example.com");
+  const result = await runAxeAudit({
+    page,
+    outputDir: testInfo.outputDir,   // where to write axe-result.json
+    // outputFile: "axe-result.json", // optional override
+    // tags: ["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"],
+  });
+  expect(result.violationCount).toBe(0);
+});
+```
+
+The focus indicator check owns its browser context (it restarts in a fresh
+context when focus triggers a navigation), so it takes a `browser` and a
+`targetUrl` instead of a `page`:
+
+```ts
+import { runFocusIndicatorCheck } from "@masup9/a11y-audit/playwright";
+
+test("focus indicators", async ({ browser }, testInfo) => {
+  const result = await runFocusIndicatorCheck({
+    browser,
+    targetUrl: "https://example.com", // or set TEST_PAGE env var
+    outputDir: testInfo.outputDir,
+    screenshot: true,                 // default: false
+    // contextOptions: { locale: "ja-JP" }, // forwarded to browser.newContext()
+  });
+  expect(result.elementsWithoutFocusStyle).toBe(0);
+});
+```
+
+### Output location resolution
+
+For every check:
+
+1. `outputPath` — full path (mutually exclusive with `outputDir`/`outputFile`).
+2. otherwise `outputDir` → `A11Y_OUTPUT_DIR` env → `process.cwd()`, joined with
+   `outputFile` → the check's default filename.
+
+Screenshots (when enabled) are written next to the result file. `outputFile`
+must be a bare filename; use `outputPath` for an absolute location.
+
+## Usage — compatibility test entries
+
+If you prefer not to write test files, point Playwright's `testMatch` at the
+bundled entries. They read `TEST_PAGE` (target URL) and `A11Y_OUTPUT_DIR`
+(output directory) and capture screenshots, reproducing the legacy script
+behavior.
+
+```ts
+// playwright.config.ts
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testMatch: ["**/node_modules/@masup9/a11y-audit/dist/test-entries/*.js"],
+});
+```
+
+```sh
+TEST_PAGE=https://example.com A11Y_OUTPUT_DIR=./a11y-results npx playwright test
+```
+
+If `testMatch` against `node_modules` is awkward in your setup, add a one-line
+local spec instead:
+
+```ts
+// tests/a11y/axe.spec.ts
+import "@masup9/a11y-audit/test-entries/axe-audit";
+```
+
+## Result types & schemas
+
+```ts
+import type { AxeAuditResult, FocusCheckResult } from "@masup9/a11y-audit/schemas";
+import { RESULT_SCHEMAS } from "@masup9/a11y-audit/schemas";
+```
+
+`RESULT_SCHEMAS` maps each check id to a hand-written JSON Schema for validating
+the `*-result.json` files at runtime.
+
+## License
+
+MIT

--- a/packages/a11y-audit/README.md
+++ b/packages/a11y-audit/README.md
@@ -85,31 +85,30 @@ must be a bare filename; use `outputPath` for an absolute location.
 
 ## Usage — compatibility test entries
 
-If you prefer not to write test files, point Playwright's `testMatch` at the
-bundled entries. They read `TEST_PAGE` (target URL) and `A11Y_OUTPUT_DIR`
-(output directory) and capture screenshots, reproducing the legacy script
-behavior.
+If you prefer not to write test bodies, re-export the bundled entries from a
+one-line local spec. The entries call `test(...)` at import time and read
+`TEST_PAGE` (target URL) and `A11Y_OUTPUT_DIR` (output directory), capturing
+screenshots — reproducing the legacy script behavior.
 
 ```ts
-// playwright.config.ts
-import { defineConfig } from "@playwright/test";
-
-export default defineConfig({
-  testMatch: ["**/node_modules/@masup9/a11y-audit/dist/test-entries/*.js"],
-});
+// tests/a11y/axe.spec.ts
+import "@masup9/a11y-audit/test-entries/axe-audit";
+// tests/a11y/focus.spec.ts
+import "@masup9/a11y-audit/test-entries/focus-indicator-check";
+// tests/a11y/reflow.spec.ts
+import "@masup9/a11y-audit/test-entries/reflow-check";
+// tests/a11y/target-size.spec.ts
+import "@masup9/a11y-audit/test-entries/target-size-check";
 ```
 
 ```sh
 TEST_PAGE=https://example.com A11Y_OUTPUT_DIR=./a11y-results npx playwright test
 ```
 
-If `testMatch` against `node_modules` is awkward in your setup, add a one-line
-local spec instead:
-
-```ts
-// tests/a11y/axe.spec.ts
-import "@masup9/a11y-audit/test-entries/axe-audit";
-```
+> **Why not `testMatch` into `node_modules`?** Playwright excludes
+> `node_modules` from test collection, so pointing `testMatch` at
+> `**/node_modules/@masup9/a11y-audit/dist/test-entries/*.js` finds no tests.
+> The one-line re-export specs above are the supported way to run the entries.
 
 ## Result types & schemas
 

--- a/packages/a11y-audit/README.md
+++ b/packages/a11y-audit/README.md
@@ -1,4 +1,4 @@
-# @masup9/a11y-audit
+# @a11y-skills/audit
 
 Playwright + axe-core based WCAG 2.2 accessibility audit functions.
 
@@ -24,7 +24,7 @@ test entries.
 ## Install
 
 ```sh
-npm install -D @masup9/a11y-audit @playwright/test @axe-core/playwright
+npm install -D @a11y-skills/audit @playwright/test @axe-core/playwright
 ```
 
 `@playwright/test` and `@axe-core/playwright` are **peer dependencies**.
@@ -39,7 +39,7 @@ returns the parsed result.
 
 ```ts
 import { test } from "@playwright/test";
-import { runAxeAudit } from "@masup9/a11y-audit/playwright";
+import { runAxeAudit } from "@a11y-skills/audit/playwright";
 
 test("axe audit", async ({ page }, testInfo) => {
   await page.goto("https://example.com");
@@ -58,7 +58,7 @@ context when focus triggers a navigation), so it takes a `browser` and a
 `targetUrl` instead of a `page`:
 
 ```ts
-import { runFocusIndicatorCheck } from "@masup9/a11y-audit/playwright";
+import { runFocusIndicatorCheck } from "@a11y-skills/audit/playwright";
 
 test("focus indicators", async ({ browser }, testInfo) => {
   const result = await runFocusIndicatorCheck({
@@ -97,13 +97,13 @@ screenshots — reproducing the legacy script behavior.
 
 ```ts
 // tests/a11y/axe.spec.ts
-import "@masup9/a11y-audit/test-entries/axe-audit";
+import "@a11y-skills/audit/test-entries/axe-audit";
 // tests/a11y/focus.spec.ts
-import "@masup9/a11y-audit/test-entries/focus-indicator-check";
+import "@a11y-skills/audit/test-entries/focus-indicator-check";
 // tests/a11y/reflow.spec.ts
-import "@masup9/a11y-audit/test-entries/reflow-check";
+import "@a11y-skills/audit/test-entries/reflow-check";
 // tests/a11y/target-size.spec.ts
-import "@masup9/a11y-audit/test-entries/target-size-check";
+import "@a11y-skills/audit/test-entries/target-size-check";
 ```
 
 ```sh
@@ -112,14 +112,14 @@ TEST_PAGE=https://example.com A11Y_OUTPUT_DIR=./a11y-results npx playwright test
 
 > **Why not `testMatch` into `node_modules`?** Playwright excludes
 > `node_modules` from test collection, so pointing `testMatch` at
-> `**/node_modules/@masup9/a11y-audit/dist/test-entries/*.js` finds no tests.
+> `**/node_modules/@a11y-skills/audit/dist/test-entries/*.js` finds no tests.
 > The one-line re-export specs above are the supported way to run the entries.
 
 ## Result types & schemas
 
 ```ts
-import type { AxeAuditResult, FocusCheckResult } from "@masup9/a11y-audit/schemas";
-import { RESULT_SCHEMAS } from "@masup9/a11y-audit/schemas";
+import type { AxeAuditResult, FocusCheckResult } from "@a11y-skills/audit/schemas";
+import { RESULT_SCHEMAS } from "@a11y-skills/audit/schemas";
 ```
 
 `RESULT_SCHEMAS` maps each check id to a hand-written JSON Schema for validating

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@masup9/a11y-audit",
+  "name": "@a11y-skills/audit",
   "version": "0.1.0",
   "description": "Playwright + axe-core based WCAG 2.2 accessibility audit functions (axe, focus indicator, reflow, target size).",
   "type": "module",

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -65,6 +65,9 @@
     "README.ja.md",
     "CHANGELOG.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.json",

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@masup9/a11y-audit",
+  "version": "0.1.0",
+  "description": "Playwright + axe-core based WCAG 2.2 accessibility audit functions (axe, focus indicator, reflow, target size).",
+  "type": "module",
+  "license": "MIT",
+  "author": {
+    "name": "masuP9",
+    "url": "https://github.com/masuP9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/masuP9/a11y-specialist-skills",
+    "directory": "packages/a11y-audit"
+  },
+  "homepage": "https://github.com/masuP9/a11y-specialist-skills/tree/main/packages/a11y-audit",
+  "bugs": {
+    "url": "https://github.com/masuP9/a11y-specialist-skills/issues"
+  },
+  "keywords": [
+    "accessibility",
+    "a11y",
+    "wcag",
+    "wcag22",
+    "playwright",
+    "axe-core",
+    "audit",
+    "focus-indicator",
+    "reflow",
+    "target-size"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./playwright": {
+      "types": "./dist/playwright/index.d.ts",
+      "import": "./dist/playwright/index.js"
+    },
+    "./schemas": {
+      "types": "./dist/schemas/index.d.ts",
+      "import": "./dist/schemas/index.js"
+    },
+    "./test-entries/axe-audit": {
+      "types": "./dist/test-entries/axe-audit.d.ts",
+      "import": "./dist/test-entries/axe-audit.js"
+    },
+    "./test-entries/focus-indicator-check": {
+      "types": "./dist/test-entries/focus-indicator-check.d.ts",
+      "import": "./dist/test-entries/focus-indicator-check.js"
+    },
+    "./test-entries/reflow-check": {
+      "types": "./dist/test-entries/reflow-check.d.ts",
+      "import": "./dist/test-entries/reflow-check.js"
+    },
+    "./test-entries/target-size-check": {
+      "types": "./dist/test-entries/target-size-check.d.ts",
+      "import": "./dist/test-entries/target-size-check.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "README.ja.md",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "pretest": "npm run build",
+    "test": "playwright test",
+    "prepublishOnly": "npm run clean && npm run build"
+  },
+  "peerDependencies": {
+    "@axe-core/playwright": "^4.10.0",
+    "@playwright/test": "^1.50.0"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.10.0",
+    "@playwright/test": "^1.50.0",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.6.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/a11y-audit/playwright.config.ts
+++ b/packages/a11y-audit/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * Playwright config for this package's own smoke tests.
  *
- * Consumers of @masup9/a11y-audit do NOT use this config — they wire the
+ * Consumers of @a11y-skills/audit do NOT use this config — they wire the
  * package's functions (or `test-entries/*`) into their own Playwright setup.
  */
 export default defineConfig({

--- a/packages/a11y-audit/playwright.config.ts
+++ b/packages/a11y-audit/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for this package's own smoke tests.
+ *
+ * Consumers of @masup9/a11y-audit do NOT use this config — they wire the
+ * package's functions (or `test-entries/*`) into their own Playwright setup.
+ */
+export default defineConfig({
+  testDir: './test',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: 'list',
+  use: {
+    ...devices['Desktop Chrome'],
+  },
+});

--- a/packages/a11y-audit/src/constants.ts
+++ b/packages/a11y-audit/src/constants.ts
@@ -1,0 +1,212 @@
+/**
+ * Constants for the WCAG audit checks shipped in @masup9/a11y-audit.
+ *
+ * Only the constants used by the four checks (axe / focus indicator / reflow /
+ * target size) are included here. Constants for the Phase 2 checks remain in the
+ * skill repository until those checks are ported.
+ */
+
+// =============================================================================
+// Common Disclaimer
+// =============================================================================
+
+/** Disclaimer to include in all audit results */
+export const AUDIT_DISCLAIMER = {
+  message:
+    '自動テストで検出できるのはWCAG違反の一部です。完全な準拠確認には手動テストが必須です。',
+  messageEn:
+    'Automated testing can only detect a subset of WCAG violations. Manual testing is required for full compliance.',
+  coverage: 'approximately 30-40%',
+  moreInfo: 'https://www.w3.org/WAI/test-evaluate/preliminary/',
+} as const;
+
+/** Console disclaimer message */
+export const DISCLAIMER_CONSOLE = `
+Note: Automated testing detects only ~30-40% of WCAG issues.
+      Manual testing is required for complete accessibility evaluation.
+`;
+
+// =============================================================================
+// Axe Audit defaults (broad WCAG coverage)
+// =============================================================================
+
+/** Default axe-core tag set (WCAG 2.0/2.1/2.2 A & AA) */
+export const DEFAULT_AXE_TAGS = [
+  'wcag2a',
+  'wcag2aa',
+  'wcag21a',
+  'wcag21aa',
+  'wcag22aa',
+] as const;
+
+// =============================================================================
+// Focus Indicator Detection Constants (WCAG 2.4.7)
+// =============================================================================
+
+/** CSS properties to check for focus style changes */
+export const FOCUS_STYLE_PROPERTIES = [
+  'outline',
+  'outlineStyle',
+  'outlineColor',
+  'outlineWidth',
+  'outlineOffset',
+  'boxShadow',
+  'backgroundColor',
+] as const;
+
+/** Selector for focusable elements */
+export const FOCUSABLE_SELECTOR = `
+  input:not([type="hidden"]):not([disabled]),
+  select:not([disabled]),
+  textarea:not([disabled]),
+  button:not([disabled]),
+  a[href],
+  [tabindex]:not([tabindex="-1"])
+`.trim();
+
+/** Extra tab iterations for safety margin */
+export const EXTRA_TAB_ITERATIONS = 10;
+
+// =============================================================================
+// Focus Obscured Detection Constants (WCAG 2.4.12)
+// =============================================================================
+
+/**
+ * Minimum overlap ratio to report as obscured (0-1)
+ * 0.2 means 20% of the focused element must be covered
+ */
+export const FOCUS_OBSCURED_MIN_OVERLAP_RATIO = 0.2;
+
+/**
+ * Minimum overlap area in pixels to report
+ * Ignores tiny overlaps (e.g., 1px border touches)
+ */
+export const FOCUS_OBSCURED_MIN_OVERLAP_PX = 8;
+
+/**
+ * Selectors to exclude from obscurer detection
+ * These elements should not be considered as obscurers
+ */
+export const FOCUS_OBSCURED_EXCLUDE_SELECTORS = [
+  '#focus-audit-overlay',
+  '.focus-audit-box',
+  '[data-focus-visited]',
+] as const;
+
+// =============================================================================
+// Output filename defaults
+// =============================================================================
+
+/** Default screenshot filename for the focus indicator check */
+export const DEFAULT_FOCUS_SCREENSHOT_FILE = 'focus-indicators.png';
+/** Default result filename for the focus indicator check */
+export const DEFAULT_FOCUS_RESULT_FILE = 'focus-indicator-result.json';
+/** Default result filename for the axe audit */
+export const DEFAULT_AXE_RESULT_FILE = 'axe-result.json';
+/** Default result filename for the reflow check */
+export const DEFAULT_REFLOW_RESULT_FILE = 'reflow-result.json';
+/** Default screenshot filename for the reflow check */
+export const DEFAULT_REFLOW_SCREENSHOT_FILE = 'reflow-screenshot.png';
+/** Default result filename for the target size check */
+export const DEFAULT_TARGET_SIZE_RESULT_FILE = 'target-size-result.json';
+/** Default screenshot filename for the target size check */
+export const DEFAULT_TARGET_SIZE_SCREENSHOT_FILE = 'target-size-screenshot.png';
+
+// =============================================================================
+// Reflow Check Constants (WCAG 1.4.10)
+// =============================================================================
+
+/** Viewport size for reflow test (320 CSS px width at 400% zoom equivalent) */
+export const REFLOW_VIEWPORT = { width: 320, height: 256 } as const;
+
+/** Tolerance for overflow detection in pixels */
+export const REFLOW_OVERFLOW_TOLERANCE = 5;
+
+/** Selector for elements to check for overflow */
+export const REFLOW_CHECK_SELECTOR = `
+  p, h1, h2, h3, h4, h5, h6, li, td, th, span, div, section, article,
+  a, button, input, select, textarea, label,
+  img, svg, table, nav, header, footer, main, aside
+`.trim();
+
+/** Elements that are allowed to have horizontal scroll */
+export const REFLOW_ALLOWED_OVERFLOW_SELECTORS = [
+  'pre',
+  'code',
+  'table[role="presentation"]',
+  '.data-table',
+  '[data-allow-scroll]',
+] as const;
+
+// =============================================================================
+// Target Size Check Constants (WCAG 2.5.5 / 2.5.8)
+// =============================================================================
+
+/**
+ * Target Size thresholds in CSS pixels
+ * - AA (2.5.8 Minimum): 24x24 px
+ * - AAA (2.5.5 Enhanced): 44x44 px
+ */
+export const TARGET_SIZE_AA = 24;
+export const TARGET_SIZE_AAA = 44;
+
+/**
+ * Selector for interactive elements (tap/click targets)
+ * Includes all elements that users may tap/click to perform actions
+ */
+export const INTERACTIVE_SELECTOR = `
+  a[href],
+  button:not([disabled]),
+  input:not([type="hidden"]):not([disabled]),
+  select:not([disabled]),
+  textarea:not([disabled]),
+  [role="button"]:not([aria-disabled="true"]),
+  [role="link"]:not([aria-disabled="true"]),
+  [role="checkbox"]:not([aria-disabled="true"]),
+  [role="radio"]:not([aria-disabled="true"]),
+  [role="switch"]:not([aria-disabled="true"]),
+  [role="menuitem"]:not([aria-disabled="true"]),
+  [role="tab"]:not([aria-disabled="true"]),
+  [role="slider"]:not([aria-disabled="true"]),
+  [role="option"]:not([aria-disabled="true"]),
+  [tabindex]:not([tabindex="-1"]):not([disabled]),
+  summary,
+  label[for],
+  [onclick]:not([disabled])
+`.trim();
+
+/**
+ * Tags that indicate inline context (for inline exception)
+ */
+export const INLINE_CONTEXT_TAGS = [
+  'p',
+  'li',
+  'dd',
+  'td',
+  'th',
+  'span',
+  'blockquote',
+  'cite',
+  'figcaption',
+] as const;
+
+/**
+ * Native input types controlled by user agent (for ua-control exception)
+ */
+export const UA_CONTROLLED_INPUT_TYPES = [
+  'checkbox',
+  'radio',
+  'range',
+  'color',
+  'date',
+  'datetime-local',
+  'month',
+  'week',
+  'time',
+  'file',
+] as const;
+
+/**
+ * Minimum text length around inline link to qualify for inline exception
+ */
+export const INLINE_CONTEXT_MIN_TEXT = 10;

--- a/packages/a11y-audit/src/constants.ts
+++ b/packages/a11y-audit/src/constants.ts
@@ -1,5 +1,5 @@
 /**
- * Constants for the WCAG audit checks shipped in @masup9/a11y-audit.
+ * Constants for the WCAG audit checks shipped in @a11y-skills/audit.
  *
  * Only the constants used by the four checks (axe / focus indicator / reflow /
  * target size) are included here. Constants for the Phase 2 checks remain in the

--- a/packages/a11y-audit/src/index.ts
+++ b/packages/a11y-audit/src/index.ts
@@ -1,13 +1,13 @@
 /**
- * @masup9/a11y-audit
+ * @a11y-skills/audit
  *
  * Playwright + axe-core based WCAG 2.2 accessibility audit functions.
  *
- * - Main subpath (`@masup9/a11y-audit`): shared types & constants.
- * - `@masup9/a11y-audit/playwright`: the `runXxx()` function API.
- * - `@masup9/a11y-audit/test-entries/*`: ready-to-run compatibility entries,
+ * - Main subpath (`@a11y-skills/audit`): shared types & constants.
+ * - `@a11y-skills/audit/playwright`: the `runXxx()` function API.
+ * - `@a11y-skills/audit/test-entries/*`: ready-to-run compatibility entries,
  *   run via a one-line local re-export spec (`import "...test-entries/axe-audit"`).
- * - `@masup9/a11y-audit/schemas`: result types & JSON Schemas.
+ * - `@a11y-skills/audit/schemas`: result types & JSON Schemas.
  */
 
 export * from './types.js';

--- a/packages/a11y-audit/src/index.ts
+++ b/packages/a11y-audit/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @masup9/a11y-audit
+ *
+ * Playwright + axe-core based WCAG 2.2 accessibility audit functions.
+ *
+ * - Main subpath (`@masup9/a11y-audit`): shared types & constants.
+ * - `@masup9/a11y-audit/playwright`: the `runXxx()` function API.
+ * - `@masup9/a11y-audit/test-entries/*`: ready-to-run compatibility entries
+ *   for use with Playwright `testMatch`.
+ * - `@masup9/a11y-audit/schemas`: result types & JSON Schemas.
+ */
+
+export * from './types.js';
+export {
+  AUDIT_DISCLAIMER,
+  DEFAULT_AXE_TAGS,
+  REFLOW_VIEWPORT,
+  TARGET_SIZE_AA,
+  TARGET_SIZE_AAA,
+} from './constants.js';

--- a/packages/a11y-audit/src/index.ts
+++ b/packages/a11y-audit/src/index.ts
@@ -5,8 +5,8 @@
  *
  * - Main subpath (`@masup9/a11y-audit`): shared types & constants.
  * - `@masup9/a11y-audit/playwright`: the `runXxx()` function API.
- * - `@masup9/a11y-audit/test-entries/*`: ready-to-run compatibility entries
- *   for use with Playwright `testMatch`.
+ * - `@masup9/a11y-audit/test-entries/*`: ready-to-run compatibility entries,
+ *   run via a one-line local re-export spec (`import "...test-entries/axe-audit"`).
  * - `@masup9/a11y-audit/schemas`: result types & JSON Schemas.
  */
 

--- a/packages/a11y-audit/src/playwright/index.ts
+++ b/packages/a11y-audit/src/playwright/index.ts
@@ -4,7 +4,7 @@
  * Import these to wire the checks into your own Playwright tests:
  *
  * ```ts
- * import { runAxeAudit } from "@masup9/a11y-audit/playwright";
+ * import { runAxeAudit } from "@a11y-skills/audit/playwright";
  *
  * test("axe", async ({ page }, testInfo) => {
  *   await page.goto(url);

--- a/packages/a11y-audit/src/playwright/index.ts
+++ b/packages/a11y-audit/src/playwright/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Function API for the WCAG audit checks.
+ *
+ * Import these to wire the checks into your own Playwright tests:
+ *
+ * ```ts
+ * import { runAxeAudit } from "@masup9/a11y-audit/playwright";
+ *
+ * test("axe", async ({ page }, testInfo) => {
+ *   await page.goto(url);
+ *   await runAxeAudit({ page, outputDir: testInfo.outputDir });
+ * });
+ * ```
+ */
+
+export { runAxeAudit, type RunAxeAuditOptions } from './runAxeAudit.js';
+export {
+  runFocusIndicatorCheck,
+  type RunFocusIndicatorCheckOptions,
+} from './runFocusIndicatorCheck.js';
+export { runReflowCheck, type RunReflowCheckOptions } from './runReflowCheck.js';
+export {
+  runTargetSizeCheck,
+  type RunTargetSizeCheckOptions,
+} from './runTargetSizeCheck.js';
+
+export {
+  resolveOutputPath,
+  type OutputLocationOptions,
+} from '../utils/test-harness.js';

--- a/packages/a11y-audit/src/playwright/runAxeAudit.ts
+++ b/packages/a11y-audit/src/playwright/runAxeAudit.ts
@@ -1,0 +1,132 @@
+/**
+ * Axe-core Accessibility Audit (broad WCAG coverage)
+ *
+ * Runs axe-core automated accessibility testing on the *current* page. The
+ * caller is responsible for navigating the page (e.g. `await page.goto(url)`)
+ * before calling this function.
+ *
+ * Axe-core cannot detect all accessibility issues — manual testing and the
+ * other checks in this package are still needed for complete coverage.
+ */
+
+import { AxeBuilder } from '@axe-core/playwright';
+import type { Page } from '@playwright/test';
+import type { AxeAuditResult } from '../types.js';
+import {
+  AUDIT_DISCLAIMER,
+  DEFAULT_AXE_TAGS,
+  DEFAULT_AXE_RESULT_FILE,
+} from '../constants.js';
+import {
+  saveAuditResult,
+  logAuditHeader,
+  logSummary,
+  logOutputPaths,
+  type OutputLocationOptions,
+} from '../utils/test-harness.js';
+
+export interface RunAxeAuditOptions extends OutputLocationOptions {
+  /** A page already navigated to the target URL. */
+  page: Page;
+  /** axe-core tags to run with (default: WCAG 2.0/2.1/2.2 A & AA). */
+  tags?: readonly string[];
+  /** axe rule overrides, forwarded to `AxeBuilder.options({ rules })`. */
+  rules?: Record<string, { enabled: boolean }>;
+}
+
+/**
+ * Run an axe-core audit against the current page, write the result JSON, and
+ * return the parsed result.
+ */
+export async function runAxeAudit(
+  options: RunAxeAuditOptions
+): Promise<AxeAuditResult> {
+  const { page, tags = DEFAULT_AXE_TAGS, rules, ...location } = options;
+
+  let builder = new AxeBuilder({ page }).withTags([...tags]);
+  if (rules) {
+    builder = builder.options({ rules });
+  }
+  const axeResults = await builder.analyze();
+
+  const result: AxeAuditResult = {
+    url: page.url(),
+    timestamp: new Date().toISOString(),
+    violations: axeResults.violations.map((v) => ({
+      id: v.id,
+      impact: v.impact ?? null,
+      description: v.description,
+      help: v.help,
+      helpUrl: v.helpUrl,
+      tags: v.tags,
+      nodes: v.nodes.map((n) => ({
+        html: n.html,
+        target: n.target as string[],
+        failureSummary: n.failureSummary,
+      })),
+    })),
+    passes: axeResults.passes.length,
+    incomplete: axeResults.incomplete.length,
+    inapplicable: axeResults.inapplicable.length,
+    violationCount: axeResults.violations.length,
+    disclaimer: AUDIT_DISCLAIMER,
+  };
+
+  // Output results
+  logAuditHeader('Axe-core Accessibility Audit Results', 'axe-core', result.url);
+
+  logSummary({
+    Timestamp: result.timestamp,
+    Violations: result.violationCount,
+    Passes: result.passes,
+    'Incomplete (needs review)': result.incomplete,
+    Inapplicable: result.inapplicable,
+  });
+
+  if (result.violations.length > 0) {
+    console.log('\n--- Violations ---');
+    result.violations.forEach((v, i) => {
+      console.log(
+        `\n  ${i + 1}. [${v.impact?.toUpperCase() || 'UNKNOWN'}] ${v.id}`
+      );
+      console.log(`     ${v.help}`);
+      console.log(`     Affected: ${v.nodes.length} element(s)`);
+      console.log(
+        `     Tags: ${v.tags.filter((t) => t.startsWith('wcag')).join(', ')}`
+      );
+
+      // Show first 3 affected elements
+      v.nodes.slice(0, 3).forEach((n, j) => {
+        const htmlPreview =
+          n.html.length > 80 ? n.html.substring(0, 80) + '...' : n.html;
+        console.log(`       ${j + 1}. ${htmlPreview}`);
+      });
+      if (v.nodes.length > 3) {
+        console.log(`       ... and ${v.nodes.length - 3} more`);
+      }
+    });
+  }
+
+  console.log(`\n--- Summary ---`);
+  if (result.violationCount === 0) {
+    console.log('No violations detected by axe-core');
+  } else {
+    const totalElements = result.violations.reduce(
+      (sum, v) => sum + v.nodes.length,
+      0
+    );
+    console.log(
+      `Found ${result.violationCount} violation type(s) affecting ${totalElements} element(s)`
+    );
+  }
+
+  // axe results already carry the disclaimer field; don't append it again.
+  const resolvedPath = saveAuditResult(result, {
+    ...location,
+    defaultFile: DEFAULT_AXE_RESULT_FILE,
+    includeDisclaimer: false,
+  });
+  logOutputPaths(resolvedPath);
+
+  return result;
+}

--- a/packages/a11y-audit/src/playwright/runFocusIndicatorCheck.ts
+++ b/packages/a11y-audit/src/playwright/runFocusIndicatorCheck.ts
@@ -1,0 +1,976 @@
+/**
+ * Focus Indicator Visibility Check
+ *
+ * WCAG 2.4.7 (Focus Visible) / 2.4.12 (Focus Not Obscured) / 3.2.1 (On Focus)
+ *
+ * Unlike the other checks, this one owns its `BrowserContext`: it tabs through
+ * every focusable element and, when focus triggers a navigation (3.2.1), it
+ * restarts in a fresh context with the offending element skipped. For that
+ * reason it accepts a `browser` (not a `page`) and navigates internally.
+ *
+ * The context this function creates is closed before it returns.
+ */
+
+import type {
+  Browser,
+  BrowserContext,
+  BrowserContextOptions,
+  Page,
+} from '@playwright/test';
+import type {
+  FocusRecord,
+  OnFocusViolation,
+  FocusCheckResult,
+  FocusObscuredIssue,
+} from '../types.js';
+import {
+  FOCUSABLE_SELECTOR,
+  FOCUS_STYLE_PROPERTIES,
+  EXTRA_TAB_ITERATIONS,
+  DEFAULT_FOCUS_RESULT_FILE,
+  DEFAULT_FOCUS_SCREENSHOT_FILE,
+  FOCUS_OBSCURED_MIN_OVERLAP_RATIO,
+  FOCUS_OBSCURED_MIN_OVERLAP_PX,
+  FOCUS_OBSCURED_EXCLUDE_SELECTORS,
+} from '../constants.js';
+import {
+  resolveOutputPath,
+  resolveScreenshotPath,
+  saveAuditResult,
+  takeAuditScreenshot,
+  requireTargetUrl,
+  logAuditHeader,
+  logOutputPaths,
+  type OutputLocationOptions,
+} from '../utils/test-harness.js';
+
+// =============================================================================
+// Browser-injected styles for marking elements
+// =============================================================================
+
+// Overlay-based annotation styles (no content DOM modification)
+const WARNING_STYLES = `
+  #focus-audit-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 99999;
+  }
+  .focus-audit-box {
+    position: absolute;
+    border: 3px solid #dc2626;
+    box-sizing: border-box;
+    pointer-events: none;
+  }
+  .focus-audit-box.navigation-violation {
+    border-color: #7c3aed;
+  }
+  .focus-audit-box.has-focus-style {
+    border-color: #16a34a;
+  }
+  .focus-audit-label {
+    position: absolute;
+    top: -22px;
+    left: -3px;
+    background: #dc2626;
+    color: white;
+    font-size: 11px;
+    font-weight: bold;
+    padding: 2px 6px;
+    border-radius: 3px;
+    white-space: nowrap;
+    font-family: system-ui, sans-serif;
+  }
+  .focus-audit-box.navigation-violation .focus-audit-label {
+    background: #7c3aed;
+  }
+  .focus-audit-box.has-focus-style .focus-audit-label {
+    background: #16a34a;
+  }
+  .focus-audit-box.focus-obscured {
+    border-color: #ea580c;
+    border-style: dashed;
+  }
+  .focus-audit-box.focus-obscured .focus-audit-label {
+    background: #ea580c;
+  }
+`;
+
+// Maximum retry attempts to avoid infinite loops
+const MAX_RETRIES = 5;
+
+export interface RunFocusIndicatorCheckOptions extends OutputLocationOptions {
+  /** The browser to create audit contexts in. */
+  browser: Browser;
+  /** Target URL. Falls back to the `TEST_PAGE` env var; required. */
+  targetUrl?: string;
+  /** Whether to capture a screenshot (default: false). */
+  screenshot?: boolean;
+  /** Options forwarded to `browser.newContext()` (locale, viewport, storageState, ...). */
+  contextOptions?: BrowserContextOptions;
+}
+
+/**
+ * Run the focus indicator check, write the result JSON (and optionally a
+ * screenshot), and return the parsed result.
+ */
+export async function runFocusIndicatorCheck(
+  options: RunFocusIndicatorCheckOptions
+): Promise<FocusCheckResult> {
+  const {
+    browser,
+    targetUrl: targetUrlOption,
+    screenshot = false,
+    contextOptions,
+    ...location
+  } = options;
+
+  const targetUrl = requireTargetUrl(targetUrlOption);
+
+  const resolvedResultPath = resolveOutputPath({
+    ...location,
+    defaultFile: DEFAULT_FOCUS_RESULT_FILE,
+  });
+  const resolvedScreenshotPath = resolveScreenshotPath(
+    resolvedResultPath,
+    DEFAULT_FOCUS_SCREENSHOT_FILE
+  );
+
+  const onFocusViolations: OnFocusViolation[] = [];
+  const focusObscuredIssues: FocusObscuredIssue[] = [];
+  const skipSelectors: string[] = [];
+  let finalFocusHistory: FocusRecord[] = [];
+  let retryCount = 0;
+  let finalPage: Page | null = null;
+  let finalContext: BrowserContext | null = null;
+
+  try {
+    // Retry loop - restart test when navigation violation is detected
+    while (retryCount < MAX_RETRIES) {
+      // Create a fresh context for each attempt to reset init scripts
+      const context = await browser.newContext(contextOptions);
+      const page = await context.newPage();
+
+      const focusHistory: FocusRecord[] = [];
+      let lastFocusedElement: {
+        tag: string;
+        role: string | null;
+        name: string;
+        selector: string;
+      } | null = null;
+      let navigationDetected = false;
+
+      // Expose function to receive focus reports from browser context
+      await page.exposeFunction(
+        'reportFocus',
+        (data: FocusRecord & { selector?: string }) => {
+          focusHistory.push(data);
+          lastFocusedElement = {
+            tag: data.tag,
+            role: data.role,
+            name: data.name,
+            selector:
+              data.selector ||
+              `${data.tag.toLowerCase()}:nth-of-type(${data.id + 1})`,
+          };
+        }
+      );
+
+      // Expose function to receive focus obscured reports (WCAG 2.4.12)
+      await page.exposeFunction(
+        'reportFocusObscured',
+        (data: FocusObscuredIssue) => {
+          focusObscuredIssues.push(data);
+        }
+      );
+
+      // Inject focus tracking script with current skip list
+      await page.addInitScript(createFocusTrackerScript, {
+        focusableSelector: FOCUSABLE_SELECTOR,
+        styleProperties: [...FOCUS_STYLE_PROPERTIES],
+        warningStyles: WARNING_STYLES,
+        skipSelectors: [...skipSelectors],
+        obscuredConfig: {
+          minOverlapRatio: FOCUS_OBSCURED_MIN_OVERLAP_RATIO,
+          minOverlapPx: FOCUS_OBSCURED_MIN_OVERLAP_PX,
+          excludeSelectors: [...FOCUS_OBSCURED_EXCLUDE_SELECTORS],
+        },
+      });
+
+      // Navigate to target page
+      await page.goto(targetUrl, { waitUntil: 'networkidle' });
+
+      // Initialize focus tracker and get element count
+      const count = await page.evaluate(() =>
+        (window as unknown as { initFocusTracker: () => number }).initFocusTracker()
+      );
+
+      // Mark elements that caused navigation violations (from previous attempts)
+      if (skipSelectors.length > 0) {
+        await page.evaluate((selectors) => {
+          selectors.forEach((sel) => {
+            const el = document.querySelector(sel);
+            if (el) {
+              el.setAttribute('data-focus-navigation-violation', '');
+              (el as HTMLElement).tabIndex = -1; // Remove from tab order
+
+              // Add annotation box to overlay (uses function from initFocusTracker)
+              const overlay = document.getElementById('focus-audit-overlay');
+              if (overlay) {
+                const rect = el.getBoundingClientRect();
+                const box = document.createElement('div');
+                box.className = 'focus-audit-box navigation-violation';
+                box.style.left = `${rect.left + window.scrollX}px`;
+                box.style.top = `${rect.top + window.scrollY}px`;
+                box.style.width = `${rect.width}px`;
+                box.style.height = `${rect.height}px`;
+
+                const labelEl = document.createElement('span');
+                labelEl.className = 'focus-audit-label';
+                labelEl.textContent = '⚠ 3.2.1 Navigation on Focus';
+                box.appendChild(labelEl);
+
+                overlay.appendChild(box);
+              }
+            }
+          });
+        }, skipSelectors);
+      }
+
+      // Tab through all elements with navigation detection
+      for (let i = 0; i < count + EXTRA_TAB_ITERATIONS; i++) {
+        const urlBeforeTab = page.url();
+
+        await page.keyboard.press('Tab');
+
+        // Get currently focused element IMMEDIATELY after Tab
+        let currentFocusedElement: {
+          tag: string;
+          role: string | null;
+          name: string;
+          selector: string;
+        } | null = null;
+        try {
+          currentFocusedElement = await page.evaluate(() => {
+            const el = document.activeElement;
+            if (!el || el === document.body) return null;
+
+            const getSelector = (element: Element): string => {
+              if (element.id) return `#${element.id}`;
+              const tag = element.tagName.toLowerCase();
+              const parent = element.parentElement;
+              if (!parent) return tag;
+              const siblings = [...parent.children].filter(
+                (c) => c.tagName === element.tagName
+              );
+              if (siblings.length === 1) return `${getSelector(parent)} > ${tag}`;
+              const index = siblings.indexOf(element) + 1;
+              return `${getSelector(parent)} > ${tag}:nth-of-type(${index})`;
+            };
+
+            return {
+              tag: el.tagName,
+              role: el.getAttribute('role'),
+              name:
+                el.getAttribute('aria-label') ||
+                el.textContent?.slice(0, 30) ||
+                '',
+              selector: getSelector(el),
+            };
+          });
+        } catch {
+          // Page might have navigated, use lastFocusedElement as fallback
+          currentFocusedElement = lastFocusedElement;
+        }
+
+        // Small wait to allow any navigation to start
+        await page.waitForTimeout(50);
+
+        // Check if navigation occurred
+        const urlAfterTab = page.url();
+        if (urlAfterTab !== urlBeforeTab) {
+          // 3.2.1 violation detected!
+          navigationDetected = true;
+
+          const culprit = currentFocusedElement || lastFocusedElement;
+          if (culprit && !skipSelectors.includes(culprit.selector)) {
+            onFocusViolations.push({
+              element: culprit,
+              fromUrl: urlBeforeTab,
+              toUrl: urlAfterTab,
+              changeType: 'navigation',
+            });
+            skipSelectors.push(culprit.selector);
+
+            console.warn(
+              `\n⚠️  WCAG 3.2.1 Violation: Focus on element caused navigation!`
+            );
+            console.warn(`    Element: <${culprit.tag}> "${culprit.name}"`);
+            console.warn(`    Selector: ${culprit.selector}`);
+            console.warn(`    From: ${urlBeforeTab}`);
+            console.warn(`    To: ${urlAfterTab}`);
+            console.warn(`    Restarting test with this element skipped...`);
+          }
+          break;
+        }
+      }
+
+      if (!navigationDetected) {
+        // Test completed successfully without navigation
+        finalFocusHistory = focusHistory;
+        finalPage = page;
+        finalContext = context;
+        break;
+      }
+
+      retryCount++;
+      if (retryCount >= MAX_RETRIES) {
+        console.warn(
+          `\n⚠️  Max retries (${MAX_RETRIES}) reached. Some elements may not have been tested.`
+        );
+        // Keep this page with its annotations for the screenshot
+        finalFocusHistory = focusHistory;
+        finalPage = page;
+        finalContext = context;
+        break;
+      }
+
+      // Close context before retry (only if we're going to retry)
+      await context.close();
+    }
+
+    // Ensure finalPage is set (should always be set by this point)
+    if (!finalPage) {
+      throw new Error('No page available for screenshot');
+    }
+
+    // Report results
+    const elementsWithoutFocusStyle = finalFocusHistory.filter(
+      (f) => !f.hasFocusStyle
+    );
+
+    if (elementsWithoutFocusStyle.length > 0) {
+      console.warn(
+        'Elements without visible focus indicator:',
+        elementsWithoutFocusStyle
+      );
+    }
+
+    // Build result
+    const result: FocusCheckResult = {
+      url: finalPage.url(),
+      totalFocusableElements: finalFocusHistory.length,
+      elementsWithFocusStyle:
+        finalFocusHistory.length - elementsWithoutFocusStyle.length,
+      elementsWithoutFocusStyle: elementsWithoutFocusStyle.length,
+      issues: elementsWithoutFocusStyle.map((el) => ({
+        tag: el.tag,
+        role: el.role,
+        name: el.name,
+      })),
+      onFocusViolations,
+      focusObscuredIssues,
+      elementsWithObscuredFocus: focusObscuredIssues.length,
+      allElements: finalFocusHistory,
+      interrupted: false,
+      screenshotPath: screenshot ? resolvedScreenshotPath : '',
+    };
+
+    // Output results
+    logAuditHeader(
+      'Focus Indicator Check Results',
+      'WCAG 2.4.7 / 2.4.12 / 3.2.1',
+      result.url
+    );
+
+    console.log(`Total focusable elements: ${result.totalFocusableElements}`);
+    console.log(`Elements with focus style: ${result.elementsWithFocusStyle}`);
+    console.log(
+      `Elements WITHOUT focus style: ${result.elementsWithoutFocusStyle}`
+    );
+    console.log(`Elements with OBSCURED focus: ${result.elementsWithObscuredFocus}`);
+
+    if (retryCount > 0) {
+      console.log(
+        `\nTest restarted ${retryCount} time(s) due to navigation violations`
+      );
+    }
+
+    // WCAG 2.4.7 summary
+    if (elementsWithoutFocusStyle.length > 0) {
+      console.log('\n--- WCAG 2.4.7: Elements Missing Focus Indicator ---');
+      elementsWithoutFocusStyle.forEach((el, i) => {
+        console.log(
+          `  ${i + 1}. <${el.tag}> "${el.name}" (role: ${el.role || 'none'})`
+        );
+      });
+    }
+
+    // WCAG 2.4.12 summary
+    if (focusObscuredIssues.length > 0) {
+      console.log('\n--- WCAG 2.4.12: Focus Obscured by Fixed/Sticky Elements ---');
+      focusObscuredIssues.forEach((issue, i) => {
+        console.log(`  ${i + 1}. <${issue.element.tag}> "${issue.element.name}"`);
+        console.log(`     Selector: ${issue.element.selector}`);
+        console.log(
+          `     Obscured ratio: ${(issue.obscuredRatio * 100).toFixed(1)}%`
+        );
+        issue.overlaps.forEach((overlap) => {
+          console.log(
+            `     Obscured by: <${overlap.obscuredBy.tag}> "${overlap.obscuredBy.name}"`
+          );
+        });
+      });
+    }
+
+    // WCAG 3.2.1 summary
+    if (onFocusViolations.length > 0) {
+      console.log('\n--- WCAG 3.2.1: Focus Triggered Context Change ---');
+      onFocusViolations.forEach((v, i) => {
+        console.log(`  ${i + 1}. <${v.element.tag}> "${v.element.name}"`);
+        console.log(`     Selector: ${v.element.selector}`);
+        console.log(`     Navigated to: ${v.toUrl}`);
+      });
+    }
+
+    let writtenScreenshotPath: string | undefined;
+    if (screenshot) {
+      writtenScreenshotPath = await takeAuditScreenshot(finalPage, {
+        path: resolvedScreenshotPath,
+      });
+    }
+    const writtenResultPath = saveAuditResult(result, {
+      ...location,
+      defaultFile: DEFAULT_FOCUS_RESULT_FILE,
+    });
+    logOutputPaths(writtenResultPath, writtenScreenshotPath);
+
+    return result;
+  } finally {
+    // Close the context this function created (the other contexts are closed
+    // on retry inside the loop).
+    if (finalContext) {
+      await finalContext.close();
+    }
+  }
+}
+
+// =============================================================================
+// Browser-injected script factory
+// =============================================================================
+
+function createFocusTrackerScript(args: {
+  focusableSelector: string;
+  styleProperties: string[];
+  warningStyles: string;
+  skipSelectors: string[];
+  obscuredConfig: {
+    minOverlapRatio: number;
+    minOverlapPx: number;
+    excludeSelectors: string[];
+  };
+}): void {
+  const { focusableSelector, styleProperties, warningStyles, skipSelectors, obscuredConfig } =
+    args;
+
+  // Add warning styles
+  const styleSheet = new CSSStyleSheet();
+  document.adoptedStyleSheets = [...document.adoptedStyleSheets, styleSheet];
+  warningStyles
+    .split('}')
+    .filter((r) => r.trim())
+    .forEach((rule, i) => {
+      try {
+        styleSheet.insertRule(rule + '}', i);
+      } catch {
+        // Ignore invalid rules
+      }
+    });
+
+  const baseStyles = new Map<Element, Record<string, string>>();
+  const elementSelectors = new Map<Element, string>();
+  let focusId = 0;
+
+  /**
+   * Generate a CSS selector for an element
+   */
+  const getSelector = (el: Element): string => {
+    if (el.id) return `#${el.id}`;
+    const tag = el.tagName.toLowerCase();
+    const parent = el.parentElement;
+    if (!parent) return tag;
+    const siblings = [...parent.children].filter((c) => c.tagName === el.tagName);
+    if (siblings.length === 1) return `${getSelector(parent)} > ${tag}`;
+    const index = siblings.indexOf(el) + 1;
+    return `${getSelector(parent)} > ${tag}:nth-of-type(${index})`;
+  };
+
+  /**
+   * Capture computed style for focus-related properties
+   */
+  const captureStyle = (el: Element): Record<string, string> => {
+    const style = window.getComputedStyle(el);
+    const result: Record<string, string> = {};
+    for (const prop of styleProperties) {
+      result[prop] = (style as unknown as Record<string, string>)[prop] ?? '';
+    }
+    return result;
+  };
+
+  /**
+   * Convert camelCase to kebab-case
+   */
+  const toKebab = (str: string): string =>
+    str.replace(/([A-Z])/g, '-$1').toLowerCase();
+
+  /**
+   * Check if element is visible
+   */
+  const isVisible = (el: Element): boolean => {
+    const style = window.getComputedStyle(el);
+    return (
+      style.display !== 'none' &&
+      style.visibility !== 'hidden' &&
+      !el.closest('[inert]')
+    );
+  };
+
+  /**
+   * Check if style changes represent a visible focus indicator
+   * outline-offset alone is not enough - need actual outline to be visible
+   */
+  const isVisibleFocusChange = (
+    diff: Record<string, string>,
+    focusedStyle: Record<string, string>
+  ): boolean => {
+    const diffKeys = Object.keys(diff);
+    if (diffKeys.length === 0) return false;
+
+    // Filter out changes that don't result in visible indicators
+    const visibleChanges = diffKeys.filter((key) => {
+      // outline-offset alone is not visible without outline
+      if (key === 'outlineOffset') {
+        const outlineStyle = focusedStyle['outlineStyle'];
+        const outlineWidth = focusedStyle['outlineWidth'];
+        if (outlineStyle === 'none' || outlineWidth === '0px') {
+          return false;
+        }
+      }
+
+      // outline-color change alone is not visible without outline
+      if (key === 'outlineColor') {
+        const outlineStyle = focusedStyle['outlineStyle'];
+        const outlineWidth = focusedStyle['outlineWidth'];
+        if (outlineStyle === 'none' || outlineWidth === '0px') {
+          return false;
+        }
+      }
+
+      // Check outline-style/outline-width actually creates visible outline
+      if (key === 'outlineStyle' || key === 'outlineWidth') {
+        const outlineStyle = focusedStyle['outlineStyle'];
+        const outlineWidth = focusedStyle['outlineWidth'];
+        if (outlineStyle === 'none' || outlineWidth === '0px') {
+          return false;
+        }
+      }
+
+      // box-shadow: none is not visible
+      if (key === 'boxShadow' && diff[key] === 'none') {
+        return false;
+      }
+
+      return true;
+    });
+
+    return visibleChanges.length > 0;
+  };
+
+  /**
+   * Check if element should be skipped (caused navigation in previous attempt)
+   */
+  const shouldSkip = (el: Element): boolean => {
+    const selector = getSelector(el);
+    return skipSelectors.includes(selector);
+  };
+
+  /**
+   * Create overlay container for annotations
+   */
+  const createOverlay = (): HTMLDivElement => {
+    let overlay = document.getElementById('focus-audit-overlay') as HTMLDivElement;
+    if (!overlay) {
+      overlay = document.createElement('div');
+      overlay.id = 'focus-audit-overlay';
+      document.body.appendChild(overlay);
+    }
+    return overlay;
+  };
+
+  /**
+   * Add annotation box to overlay for an element
+   */
+  const addAnnotationBox = (el: Element, label: string, cssClass: string): void => {
+    const overlay = createOverlay();
+    const rect = el.getBoundingClientRect();
+
+    const box = document.createElement('div');
+    box.className = `focus-audit-box ${cssClass}`;
+    box.style.left = `${rect.left + window.scrollX}px`;
+    box.style.top = `${rect.top + window.scrollY}px`;
+    box.style.width = `${rect.width}px`;
+    box.style.height = `${rect.height}px`;
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'focus-audit-label';
+    labelEl.textContent = label;
+    box.appendChild(labelEl);
+
+    overlay.appendChild(box);
+  };
+
+  /**
+   * Calculate rectangle intersection
+   */
+  const getIntersection = (
+    rect1: DOMRect,
+    rect2: DOMRect
+  ): { left: number; top: number; width: number; height: number } | null => {
+    const left = Math.max(rect1.left, rect2.left);
+    const top = Math.max(rect1.top, rect2.top);
+    const right = Math.min(rect1.right, rect2.right);
+    const bottom = Math.min(rect1.bottom, rect2.bottom);
+
+    if (left < right && top < bottom) {
+      return {
+        left,
+        top,
+        width: right - left,
+        height: bottom - top,
+      };
+    }
+    return null;
+  };
+
+  /**
+   * Get all fixed/sticky positioned elements that could obscure focus
+   */
+  const getObscurerCandidates = (): Element[] => {
+    const all = document.querySelectorAll('*');
+    const candidates: Element[] = [];
+
+    all.forEach((el) => {
+      // Skip excluded selectors
+      if (obscuredConfig.excludeSelectors.some((sel) => el.matches(sel))) {
+        return;
+      }
+
+      const style = window.getComputedStyle(el);
+      const position = style.position;
+
+      // Only fixed and sticky positioned elements can obscure
+      if (position !== 'fixed' && position !== 'sticky') {
+        return;
+      }
+
+      // Must be visible
+      if (
+        style.display === 'none' ||
+        style.visibility === 'hidden' ||
+        parseFloat(style.opacity) === 0
+      ) {
+        return;
+      }
+
+      // Must have area
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) {
+        return;
+      }
+
+      candidates.push(el);
+    });
+
+    return candidates;
+  };
+
+  /**
+   * Check if an obscurer is actually in front of the focused element
+   */
+  const isActuallyObscuring = (
+    focusedEl: Element,
+    obscurer: Element,
+    intersection: { left: number; top: number; width: number; height: number }
+  ): boolean => {
+    // Calculate safe sample offsets (clamped to intersection bounds)
+    const marginX = Math.min(2, intersection.width / 4);
+    const marginY = Math.min(2, intersection.height / 4);
+
+    // For very small intersections, only use center point
+    const useOnlyCenter = intersection.width < 6 || intersection.height < 6;
+
+    // Sample points within the intersection area (clamped to bounds)
+    const samplePoints = useOnlyCenter
+      ? [
+          {
+            x: intersection.left + intersection.width / 2,
+            y: intersection.top + intersection.height / 2,
+          },
+        ]
+      : [
+          {
+            x: intersection.left + intersection.width / 2,
+            y: intersection.top + intersection.height / 2,
+          }, // center
+          { x: intersection.left + marginX, y: intersection.top + marginY }, // top-left
+          {
+            x: intersection.left + intersection.width - marginX,
+            y: intersection.top + marginY,
+          }, // top-right
+          {
+            x: intersection.left + marginX,
+            y: intersection.top + intersection.height - marginY,
+          }, // bottom-left
+          {
+            x: intersection.left + intersection.width - marginX,
+            y: intersection.top + intersection.height - marginY,
+          }, // bottom-right
+        ];
+
+    let obscuringCount = 0;
+    let nullCount = 0;
+
+    for (const point of samplePoints) {
+      const topEl = document.elementFromPoint(point.x, point.y);
+      if (topEl) {
+        if (topEl === obscurer || obscurer.contains(topEl)) {
+          obscuringCount++;
+        }
+      } else {
+        nullCount++;
+      }
+    }
+
+    // For small intersections (center only), require the center to confirm obscuring
+    if (useOnlyCenter) {
+      if (obscuringCount >= 1) return true;
+      if (nullCount === 1) {
+        return checkZIndexOrder(focusedEl, obscurer);
+      }
+      return false;
+    }
+
+    // For normal intersections: require at least 2/5 points
+    if (obscuringCount >= 2) return true;
+    if (nullCount >= 3) {
+      return checkZIndexOrder(focusedEl, obscurer);
+    }
+    return false;
+  };
+
+  /**
+   * Fallback z-index comparison for elements with pointer-events:none
+   */
+  const checkZIndexOrder = (focusedEl: Element, obscurer: Element): boolean => {
+    const focusedStyle = window.getComputedStyle(focusedEl);
+    const obscurerStyle = window.getComputedStyle(obscurer);
+
+    const focusedZ = parseInt(focusedStyle.zIndex, 10) || 0;
+    const obscurerZ = parseInt(obscurerStyle.zIndex, 10) || 0;
+
+    if (obscurerZ > focusedZ) return true;
+
+    const focusedPos = focusedStyle.position;
+    const obscurerPos = obscurerStyle.position;
+
+    if (
+      obscurerPos === 'fixed' &&
+      (focusedPos === 'static' || focusedPos === 'relative')
+    ) {
+      return true;
+    }
+
+    return false;
+  };
+
+  /**
+   * Check if focused element is obscured by fixed/sticky elements (WCAG 2.4.12)
+   */
+  const checkFocusObscured = (focusedEl: Element): void => {
+    const focusedRect = focusedEl.getBoundingClientRect();
+    const focusedArea = focusedRect.width * focusedRect.height;
+
+    if (focusedArea === 0) return;
+
+    const obscurers = getObscurerCandidates();
+    const overlaps: Array<{
+      obscuredBy: { tag: string; role: string | null; name: string; selector: string };
+      overlapRect: { left: number; top: number; width: number; height: number };
+      overlapArea: number;
+    }> = [];
+
+    let totalOverlapArea = 0;
+
+    obscurers.forEach((obscurer) => {
+      // Don't check against self or ancestors/descendants
+      if (
+        obscurer === focusedEl ||
+        obscurer.contains(focusedEl) ||
+        focusedEl.contains(obscurer)
+      ) {
+        return;
+      }
+
+      const obscurerRect = obscurer.getBoundingClientRect();
+      const intersection = getIntersection(focusedRect, obscurerRect);
+
+      if (!intersection) return;
+
+      const overlapArea = intersection.width * intersection.height;
+
+      // Check minimum thresholds
+      if (overlapArea < obscuredConfig.minOverlapPx) return;
+
+      // Verify that the obscurer is actually in front using elementFromPoint
+      if (!isActuallyObscuring(focusedEl, obscurer, intersection)) {
+        return;
+      }
+
+      totalOverlapArea += overlapArea;
+
+      overlaps.push({
+        obscuredBy: {
+          tag: obscurer.tagName,
+          role: obscurer.getAttribute('role'),
+          name:
+            obscurer.getAttribute('aria-label') ||
+            obscurer.textContent?.slice(0, 30) ||
+            '',
+          selector: getSelector(obscurer),
+        },
+        overlapRect: intersection,
+        overlapArea,
+      });
+    });
+
+    // Clamp ratio to max 1.0 to handle overlapping obscurers covering same region
+    const obscuredRatio = Math.min(totalOverlapArea / focusedArea, 1.0);
+
+    // Only report if obscured ratio exceeds threshold
+    if (obscuredRatio >= obscuredConfig.minOverlapRatio && overlaps.length > 0) {
+      // Add visual annotation
+      addAnnotationBox(
+        focusedEl,
+        `⚠ 2.4.12 Obscured (${(obscuredRatio * 100).toFixed(0)}%)`,
+        'focus-obscured'
+      );
+
+      // Report to test
+      (
+        window as unknown as {
+          reportFocusObscured: (data: unknown) => void;
+        }
+      ).reportFocusObscured({
+        element: {
+          tag: focusedEl.tagName,
+          role: focusedEl.getAttribute('role'),
+          name:
+            focusedEl.getAttribute('aria-label') ||
+            focusedEl.textContent?.slice(0, 30) ||
+            '',
+          selector: getSelector(focusedEl),
+        },
+        elementRect: {
+          left: focusedRect.left,
+          top: focusedRect.top,
+          width: focusedRect.width,
+          height: focusedRect.height,
+        },
+        overlaps,
+        obscuredRatio,
+      });
+    }
+  };
+
+  /**
+   * Initialize focus tracker - called after page load
+   */
+  (window as unknown as { initFocusTracker: () => number }).initFocusTracker = () => {
+    // Create overlay container
+    createOverlay();
+
+    const elements = [...document.querySelectorAll(focusableSelector)]
+      .filter(isVisible)
+      .filter((el) => !shouldSkip(el));
+    elements.forEach((el) => {
+      baseStyles.set(el, captureStyle(el));
+      elementSelectors.set(el, getSelector(el));
+    });
+    return elements.length;
+  };
+
+  /**
+   * Handle focus events
+   */
+  document.addEventListener('focusin', (e) => {
+    const el = e.target as Element;
+    if (el.hasAttribute('data-focus-visited')) return;
+    if (el.hasAttribute('data-focus-navigation-violation')) return;
+
+    const pre = baseStyles.get(el);
+    const focused = captureStyle(el);
+    const diff: Record<string, string> = {};
+
+    if (pre) {
+      for (const p of Object.keys(pre)) {
+        const focusedValue = focused[p];
+        if (pre[p] !== focusedValue && focusedValue !== undefined) {
+          diff[p] = focusedValue;
+        }
+      }
+    }
+
+    const id = focusId++;
+    el.setAttribute('data-focus-visited', String(id));
+
+    // Check if changes are actually visible (not just outline-offset without outline)
+    const hasFocusStyle = isVisibleFocusChange(diff, focused);
+
+    if (hasFocusStyle) {
+      // Preserve focus appearance for screenshot
+      const cssText = Object.entries(diff)
+        .map(([p, v]) => `${toKebab(p)}: ${v}`)
+        .join('; ');
+      styleSheet.insertRule(
+        `[data-focus-visited="${id}"] { ${cssText} }`,
+        styleSheet.cssRules.length
+      );
+      // Add green annotation box for elements with focus style
+      addAnnotationBox(el, '✓ Focus Style', 'has-focus-style');
+    } else {
+      // Mark element as missing focus style (data attribute for tracking)
+      el.setAttribute('data-focus-missing', '');
+      // Add red annotation box to overlay (no content DOM modification)
+      addAnnotationBox(el, '⚠ No Focus Style', '');
+    }
+
+    // Report to test
+    (
+      window as unknown as { reportFocus: (data: unknown) => void }
+    ).reportFocus({
+      id,
+      tag: el.tagName,
+      role: el.getAttribute('role'),
+      name: el.getAttribute('aria-label') || el.textContent?.slice(0, 30),
+      hasFocusStyle,
+      diff,
+      selector: elementSelectors.get(el) || getSelector(el),
+    });
+
+    // Check for WCAG 2.4.12 - focus obscured by fixed/sticky elements
+    checkFocusObscured(el);
+  });
+}

--- a/packages/a11y-audit/src/playwright/runFocusIndicatorCheck.ts
+++ b/packages/a11y-audit/src/playwright/runFocusIndicatorCheck.ts
@@ -145,13 +145,15 @@ export async function runFocusIndicatorCheck(
   let finalFocusHistory: FocusRecord[] = [];
   let retryCount = 0;
   let finalPage: Page | null = null;
-  let finalContext: BrowserContext | null = null;
+  // The context for the current attempt. Held outside the loop so it is always
+  // closed in `finally`, including if an attempt throws mid-way.
+  let context: BrowserContext | null = null;
 
   try {
     // Retry loop - restart test when navigation violation is detected
     while (retryCount < MAX_RETRIES) {
       // Create a fresh context for each attempt to reset init scripts
-      const context = await browser.newContext(contextOptions);
+      context = await browser.newContext(contextOptions);
       const page = await context.newPage();
 
       const focusHistory: FocusRecord[] = [];
@@ -322,7 +324,6 @@ export async function runFocusIndicatorCheck(
         // Test completed successfully without navigation
         finalFocusHistory = focusHistory;
         finalPage = page;
-        finalContext = context;
         break;
       }
 
@@ -334,12 +335,12 @@ export async function runFocusIndicatorCheck(
         // Keep this page with its annotations for the screenshot
         finalFocusHistory = focusHistory;
         finalPage = page;
-        finalContext = context;
         break;
       }
 
       // Close context before retry (only if we're going to retry)
       await context.close();
+      context = null;
     }
 
     // Ensure finalPage is set (should always be set by this point)
@@ -450,10 +451,11 @@ export async function runFocusIndicatorCheck(
 
     return result;
   } finally {
-    // Close the context this function created (the other contexts are closed
-    // on retry inside the loop).
-    if (finalContext) {
-      await finalContext.close();
+    // Close the context for the final/in-flight attempt. Contexts from earlier
+    // retries are already closed inside the loop; this also covers the case
+    // where an attempt throws mid-way.
+    if (context) {
+      await context.close();
     }
   }
 }

--- a/packages/a11y-audit/src/playwright/runReflowCheck.ts
+++ b/packages/a11y-audit/src/playwright/runReflowCheck.ts
@@ -1,0 +1,130 @@
+/**
+ * Reflow Check — WCAG 1.4.10 (Reflow)
+ *
+ * Sets the viewport to a narrow width (default 320px, equivalent to 400% zoom
+ * on a 1280px viewport), then detects horizontal scrolling, overflowing
+ * elements, and clipped text.
+ *
+ * The caller is responsible for navigating the page before calling this
+ * function. This function sets the viewport size itself so the measurement is
+ * taken at the reflow width regardless of how the page was loaded.
+ *
+ * Limitations:
+ * - Cannot distinguish acceptable horizontal scroll (e.g., data tables)
+ * - Does not verify functional reflow for complex widgets
+ */
+
+import type { Page } from '@playwright/test';
+import type {
+  ReflowCheckResult,
+  ReflowIssue,
+  ClippedTextElement,
+} from '../types.js';
+import {
+  REFLOW_VIEWPORT,
+  REFLOW_OVERFLOW_TOLERANCE,
+  REFLOW_CHECK_SELECTOR,
+  REFLOW_ALLOWED_OVERFLOW_SELECTORS,
+  DEFAULT_REFLOW_RESULT_FILE,
+  DEFAULT_REFLOW_SCREENSHOT_FILE,
+} from '../constants.js';
+import { createLayoutChecker } from '../utils/layout.js';
+import {
+  saveAuditResult,
+  takeAuditScreenshot,
+  resolveScreenshotPath,
+  logAuditHeader,
+  logSummary,
+  logIssueList,
+  logOutputPaths,
+  type OutputLocationOptions,
+} from '../utils/test-harness.js';
+
+export interface RunReflowCheckOptions extends OutputLocationOptions {
+  /** A page already navigated to the target URL. */
+  page: Page;
+  /** Viewport to measure reflow at (default: 320x256). */
+  viewport?: { width: number; height: number };
+  /** Overflow tolerance in pixels (default: 5). */
+  overflowTolerance?: number;
+  /** Whether to capture a screenshot next to the result file (default: false). */
+  screenshot?: boolean;
+}
+
+/**
+ * Run the reflow check against the current page, write the result JSON
+ * (and optionally a screenshot), and return the parsed result.
+ */
+export async function runReflowCheck(
+  options: RunReflowCheckOptions
+): Promise<ReflowCheckResult> {
+  const {
+    page,
+    viewport = REFLOW_VIEWPORT,
+    overflowTolerance = REFLOW_OVERFLOW_TOLERANCE,
+    screenshot = false,
+    ...location
+  } = options;
+
+  await page.setViewportSize({ width: viewport.width, height: viewport.height });
+
+  const layoutResult = await page.evaluate(createLayoutChecker, {
+    viewportWidth: viewport.width,
+    overflowTolerance,
+    checkSelector: REFLOW_CHECK_SELECTOR,
+    allowedOverflowSelectors: [...REFLOW_ALLOWED_OVERFLOW_SELECTORS],
+  });
+
+  const result: ReflowCheckResult = {
+    url: page.url(),
+    viewport: { width: viewport.width, height: viewport.height },
+    ...layoutResult,
+  };
+
+  // Output results
+  logAuditHeader('Reflow Check Results', 'WCAG 1.4.10', result.url);
+
+  logSummary({
+    Viewport: `${result.viewport.width}x${result.viewport.height}`,
+    'Document scroll width': `${result.documentScrollWidth}px`,
+    'Document client width': `${result.documentClientWidth}px`,
+    'Horizontal scroll': result.hasHorizontalScroll,
+    'Overflowing elements': result.overflowingElements.length,
+    'Clipped text elements': result.clippedTextElements.length,
+  });
+
+  logIssueList<ReflowIssue>(
+    'Overflowing Elements',
+    result.overflowingElements,
+    (el, i) => [
+      `${i + 1}. <${el.tagName}> "${el.selector}"`,
+      `   rect.right: ${el.rect.right}px (viewport: ${el.viewportWidth}px)`,
+    ]
+  );
+
+  logIssueList<ClippedTextElement>(
+    'Clipped Text Elements',
+    result.clippedTextElements,
+    (el, i) => [
+      `${i + 1}. <${el.tagName}> "${el.selector}"`,
+      `   scrollWidth: ${el.scrollWidth}px, clientWidth: ${el.clientWidth}px`,
+      `   overflow: ${el.overflow}, overflowX: ${el.overflowX}`,
+    ]
+  );
+
+  const resolvedPath = saveAuditResult(result, {
+    ...location,
+    defaultFile: DEFAULT_REFLOW_RESULT_FILE,
+  });
+
+  let screenshotPath: string | undefined;
+  if (screenshot) {
+    screenshotPath = await takeAuditScreenshot(page, {
+      path: resolveScreenshotPath(resolvedPath, DEFAULT_REFLOW_SCREENSHOT_FILE),
+    });
+  }
+
+  logOutputPaths(resolvedPath, screenshotPath);
+
+  return result;
+}

--- a/packages/a11y-audit/src/playwright/runTargetSizeCheck.ts
+++ b/packages/a11y-audit/src/playwright/runTargetSizeCheck.ts
@@ -1,0 +1,577 @@
+/**
+ * Target Size Check
+ *
+ * WCAG 2.5.8 (Target Size Minimum - AA): 24x24 CSS px
+ * WCAG 2.5.5 (Target Size Enhanced - AAA): 44x44 CSS px
+ *
+ * The caller is responsible for navigating the page before calling this
+ * function.
+ *
+ * Note: when `screenshot` is enabled this function appends an annotation
+ * overlay to the page DOM before capturing the screenshot.
+ *
+ * Limitations:
+ * - Essential exception requires manual review
+ * - Cannot detect all redundant target cases
+ * - CSS transform may affect measurements
+ */
+
+import type { Page } from '@playwright/test';
+import type {
+  TargetSizeIssue,
+  TargetSizeCheckResult,
+  TargetSizeException,
+} from '../types.js';
+import {
+  INTERACTIVE_SELECTOR,
+  TARGET_SIZE_AA,
+  TARGET_SIZE_AAA,
+  INLINE_CONTEXT_TAGS,
+  UA_CONTROLLED_INPUT_TYPES,
+  INLINE_CONTEXT_MIN_TEXT,
+  DEFAULT_TARGET_SIZE_RESULT_FILE,
+  DEFAULT_TARGET_SIZE_SCREENSHOT_FILE,
+} from '../constants.js';
+import {
+  saveAuditResult,
+  takeAuditScreenshot,
+  resolveScreenshotPath,
+  logAuditHeader,
+  logSummary,
+  logIssueList,
+  logOutputPaths,
+  type OutputLocationOptions,
+} from '../utils/test-harness.js';
+import { addPageAnnotations, type AnnotationConfig } from '../utils/annotations.js';
+
+/** Basic target info collected from DOM */
+interface BasicTargetInfo {
+  selector: string;
+  tagName: string;
+  role: string | null;
+  width: number;
+  height: number;
+  href: string | null;
+  inputType: string | null;
+  appearance: string;
+  parentTag: string | null;
+  parentTextLength: number;
+  boundingRect: {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+  };
+}
+
+/**
+ * Collect basic target information from DOM (runs in browser context).
+ */
+function collectBasicTargetInfo(interactiveSelector: string): BasicTargetInfo[] {
+  function getUniqueSelector(element: Element, elementIndex: number): string {
+    if (element.id) {
+      return `#${CSS.escape(element.id)}`;
+    }
+    const path: string[] = [];
+    let current: Element | null = element;
+    while (current && current !== document.body) {
+      let selector = current.tagName.toLowerCase();
+      const parent: Element | null = current.parentElement;
+      if (parent) {
+        const siblings = Array.from(parent.children).filter(
+          (c) => c.tagName === current!.tagName
+        );
+        if (siblings.length > 1) {
+          const index = siblings.indexOf(current) + 1;
+          selector += `:nth-of-type(${index})`;
+        }
+      }
+      path.unshift(selector);
+      current = parent;
+    }
+    return path.length > 0 ? path.join(' > ') : `[data-index="${elementIndex}"]`;
+  }
+
+  const targets: BasicTargetInfo[] = [];
+  const elements = document.querySelectorAll(interactiveSelector);
+
+  elements.forEach((element, index) => {
+    const el = element as HTMLElement;
+    const rect = el.getBoundingClientRect();
+
+    // Skip invisible elements
+    if (rect.width === 0 || rect.height === 0) {
+      return;
+    }
+
+    // Skip elements outside viewport (likely hidden)
+    if (rect.bottom < 0 || rect.right < 0) {
+      return;
+    }
+
+    const computedStyle = getComputedStyle(el);
+    if (
+      computedStyle.visibility === 'hidden' ||
+      computedStyle.display === 'none'
+    ) {
+      return;
+    }
+
+    const tagName = el.tagName.toLowerCase();
+    const role = el.getAttribute('role');
+    const inputType = el instanceof HTMLInputElement ? el.type : null;
+    const href = el instanceof HTMLAnchorElement ? el.href : null;
+
+    // Get parent info for inline exception check
+    const parent = el.parentElement;
+    const parentTag = parent ? parent.tagName.toLowerCase() : null;
+    const parentTextLength = parent ? (parent.textContent || '').length : 0;
+
+    targets.push({
+      selector: getUniqueSelector(element, index),
+      tagName,
+      role,
+      width: Math.round(rect.width * 100) / 100,
+      height: Math.round(rect.height * 100) / 100,
+      href,
+      inputType,
+      appearance: computedStyle.appearance,
+      parentTag,
+      parentTextLength,
+      boundingRect: {
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+      },
+    });
+  });
+
+  return targets;
+}
+
+/**
+ * Parse accessible name from ariaSnapshot output.
+ */
+function parseAccessibleName(snapshot: string): string | null {
+  // ariaSnapshot format: "- role \"accessible name\"" or "- role \"accessible name\" [state]"
+  const match = snapshot.match(/^- \w+(?:\s+"([^"]*)")?/);
+  if (match && match[1]) {
+    return match[1];
+  }
+  return null;
+}
+
+/**
+ * Check if element qualifies for inline exception.
+ */
+function checkInlineException(
+  target: BasicTargetInfo,
+  inlineContextTags: readonly string[],
+  minTextLength: number
+): { applies: boolean; details: string | null } {
+  // Only links typically qualify for inline exception
+  if (target.tagName !== 'a' || !target.href) {
+    return { applies: false, details: null };
+  }
+
+  if (
+    target.parentTag &&
+    inlineContextTags.includes(target.parentTag) &&
+    target.parentTextLength >= minTextLength
+  ) {
+    return {
+      applies: true,
+      details: `Inline link within <${target.parentTag}>, surrounding text: ${target.parentTextLength} chars`,
+    };
+  }
+
+  return { applies: false, details: null };
+}
+
+/**
+ * Check if element qualifies for UA control exception.
+ */
+function checkUAControlException(
+  target: BasicTargetInfo,
+  uaControlledTypes: readonly string[]
+): { applies: boolean; details: string | null } {
+  // Check native form controls that haven't been restyled
+  if (target.tagName === 'select') {
+    if (target.appearance !== 'none') {
+      return {
+        applies: true,
+        details: 'Native <select> element with default appearance',
+      };
+    }
+  }
+
+  if (
+    target.tagName === 'input' &&
+    target.inputType &&
+    uaControlledTypes.includes(target.inputType)
+  ) {
+    if (target.appearance !== 'none') {
+      return {
+        applies: true,
+        details: `Native <input type="${target.inputType}"> with default appearance`,
+      };
+    }
+  }
+
+  return { applies: false, details: null };
+}
+
+/**
+ * Check for redundant targets (same href with at least one meeting size).
+ */
+function findRedundantTargets(
+  targets: BasicTargetInfo[]
+): Map<string, BasicTargetInfo[]> {
+  const byHref = new Map<string, BasicTargetInfo[]>();
+
+  for (const target of targets) {
+    if (target.href) {
+      const existing = byHref.get(target.href) || [];
+      existing.push(target);
+      byHref.set(target.href, existing);
+    }
+  }
+
+  return byHref;
+}
+
+/**
+ * Check if target has adequate spacing from adjacent targets.
+ */
+function checkSpacingException(
+  target: BasicTargetInfo,
+  allTargets: BasicTargetInfo[],
+  requiredSpacing: number
+): { applies: boolean; details: string | null } {
+  const targetRect = target.boundingRect;
+
+  for (const other of allTargets) {
+    if (other.selector === target.selector) {
+      continue;
+    }
+
+    const otherRect = other.boundingRect;
+
+    // Calculate distance between edges
+    const horizontalGap = Math.max(
+      0,
+      Math.max(otherRect.left - targetRect.right, targetRect.left - otherRect.right)
+    );
+    const verticalGap = Math.max(
+      0,
+      Math.max(otherRect.top - targetRect.bottom, targetRect.top - otherRect.bottom)
+    );
+
+    // If adjacent (gaps are small), check if spacing is adequate
+    if (horizontalGap < requiredSpacing && verticalGap < requiredSpacing) {
+      // Not enough spacing
+      return { applies: false, details: null };
+    }
+  }
+
+  // All adjacent targets have adequate spacing
+  return {
+    applies: true,
+    details: `No adjacent targets within ${requiredSpacing}px`,
+  };
+}
+
+/**
+ * Analyze targets and categorize by pass/fail level.
+ */
+function analyzeTargets(
+  targets: Array<BasicTargetInfo & { accessibleName: string | null }>,
+  aaThreshold: number,
+  aaaThreshold: number
+): {
+  failAA: TargetSizeIssue[];
+  failAAAOnly: TargetSizeIssue[];
+  passCount: number;
+  excepted: TargetSizeIssue[];
+} {
+  const failAA: TargetSizeIssue[] = [];
+  const failAAAOnly: TargetSizeIssue[] = [];
+  const excepted: TargetSizeIssue[] = [];
+  let passCount = 0;
+
+  // Build href map for redundancy check
+  const hrefMap = findRedundantTargets(targets);
+
+  for (const target of targets) {
+    const minDimension = Math.min(target.width, target.height);
+
+    // Determine level
+    let level: 'fail-aa' | 'fail-aaa-only' | 'pass';
+    if (minDimension >= aaaThreshold) {
+      passCount++;
+      continue;
+    } else if (minDimension >= aaThreshold) {
+      level = 'fail-aaa-only';
+    } else {
+      level = 'fail-aa';
+    }
+
+    // Check exceptions (only relevant for fail-aa)
+    let exception: TargetSizeException | null = null;
+    let exceptionDetails: string | null = null;
+
+    if (level === 'fail-aa') {
+      // Check inline exception
+      const inlineCheck = checkInlineException(
+        target,
+        INLINE_CONTEXT_TAGS,
+        INLINE_CONTEXT_MIN_TEXT
+      );
+      if (inlineCheck.applies) {
+        exception = 'inline';
+        exceptionDetails = inlineCheck.details;
+      }
+
+      // Check UA control exception
+      if (!exception) {
+        const uaCheck = checkUAControlException(target, UA_CONTROLLED_INPUT_TYPES);
+        if (uaCheck.applies) {
+          exception = 'ua-control';
+          exceptionDetails = uaCheck.details;
+        }
+      }
+
+      // Check redundant exception
+      if (!exception && target.href) {
+        const sameHrefTargets = hrefMap.get(target.href) || [];
+        const hasLargerTarget = sameHrefTargets.some(
+          (t) =>
+            t.selector !== target.selector &&
+            Math.min(t.width, t.height) >= aaThreshold
+        );
+        if (hasLargerTarget) {
+          exception = 'redundant';
+          exceptionDetails = `Another link to same URL meets size requirement`;
+        }
+      }
+
+      // Check spacing exception
+      if (!exception) {
+        const spacingCheck = checkSpacingException(target, targets, aaThreshold);
+        if (spacingCheck.applies) {
+          exception = 'spacing';
+          exceptionDetails = spacingCheck.details;
+        }
+      }
+    }
+
+    const issue: TargetSizeIssue = {
+      selector: target.selector,
+      tagName: target.tagName,
+      role: target.role,
+      accessibleName: target.accessibleName,
+      width: target.width,
+      height: target.height,
+      minDimension: Math.round(minDimension * 100) / 100,
+      level,
+      exception,
+      exceptionDetails,
+      href: target.href,
+    };
+
+    if (exception) {
+      excepted.push(issue);
+    } else if (level === 'fail-aa') {
+      failAA.push(issue);
+    } else {
+      failAAAOnly.push(issue);
+    }
+  }
+
+  return { failAA, failAAAOnly, passCount, excepted };
+}
+
+export interface RunTargetSizeCheckOptions extends OutputLocationOptions {
+  /** A page already navigated to the target URL. */
+  page: Page;
+  /** Minimum (AA) threshold in CSS px (default: 24). */
+  aaThreshold?: number;
+  /** Enhanced (AAA) threshold in CSS px (default: 44). */
+  aaaThreshold?: number;
+  /** Whether to capture an annotated screenshot (default: false). Mutates the page DOM. */
+  screenshot?: boolean;
+}
+
+/**
+ * Run the target size check against the current page, write the result JSON
+ * (and optionally an annotated screenshot), and return the parsed result.
+ */
+export async function runTargetSizeCheck(
+  options: RunTargetSizeCheckOptions
+): Promise<TargetSizeCheckResult> {
+  const {
+    page,
+    aaThreshold = TARGET_SIZE_AA,
+    aaaThreshold = TARGET_SIZE_AAA,
+    screenshot = false,
+    ...location
+  } = options;
+
+  // Collect basic target info from DOM
+  const basicTargets = await page.evaluate(
+    collectBasicTargetInfo,
+    INTERACTIVE_SELECTOR
+  );
+
+  // Enhance with accessible names via ariaSnapshot()
+  const targets: Array<BasicTargetInfo & { accessibleName: string | null }> = [];
+  for (const basicTarget of basicTargets) {
+    let accessibleName: string | null = null;
+
+    try {
+      const locator = page.locator(basicTarget.selector).first();
+      const snapshot = await locator.ariaSnapshot();
+      accessibleName = parseAccessibleName(snapshot);
+    } catch {
+      // If ariaSnapshot fails, accessibleName remains null
+    }
+
+    targets.push({
+      ...basicTarget,
+      accessibleName,
+    });
+  }
+
+  // Analyze targets
+  const { failAA, failAAAOnly, passCount, excepted } = analyzeTargets(
+    targets,
+    aaThreshold,
+    aaaThreshold
+  );
+
+  const result: TargetSizeCheckResult = {
+    url: page.url(),
+    totalTargetsChecked: targets.length,
+    failAA,
+    failAAAOnly,
+    passedTargets: passCount,
+    exceptedTargets: excepted,
+    summary: {
+      failAACount: failAA.length,
+      failAAAOnlyCount: failAAAOnly.length,
+      passCount,
+      exceptedCount: excepted.length,
+    },
+  };
+
+  // Output results
+  logAuditHeader('Target Size Check Results', 'WCAG 2.5.5 / 2.5.8', result.url);
+
+  logSummary({
+    'Total targets checked': result.totalTargetsChecked,
+  });
+
+  console.log('\nSummary:');
+  console.log(`  Pass (>= ${aaaThreshold}px): ${result.summary.passCount}`);
+  console.log(
+    `  Fail AAA only (${aaThreshold}-${aaaThreshold - 1}px): ${result.summary.failAAAOnlyCount}`
+  );
+  console.log(`  Fail AA (< ${aaThreshold}px): ${result.summary.failAACount}`);
+  console.log(`  Possible exceptions: ${result.summary.exceptedCount}`);
+
+  logIssueList<TargetSizeIssue>(
+    `Fail AA (< ${aaThreshold}px) - Requires Fix`,
+    failAA,
+    (el, i) => {
+      const lines = [
+        `${i + 1}. <${el.tagName}> "${el.selector}"`,
+        `   Size: ${el.width}x${el.height}px (min: ${el.minDimension}px)`,
+        `   Name: "${el.accessibleName || 'none'}"`,
+      ];
+      if (el.exception) {
+        lines.push(`   Exception: ${el.exception} - ${el.exceptionDetails}`);
+      }
+      return lines;
+    }
+  );
+
+  logIssueList<TargetSizeIssue>(
+    `Fail AAA Only (${aaThreshold}-${aaaThreshold - 1}px) - Recommended Fix`,
+    failAAAOnly,
+    (el, i) => [
+      `${i + 1}. <${el.tagName}> "${el.selector}"`,
+      `   Size: ${el.width}x${el.height}px (min: ${el.minDimension}px)`,
+      `   Name: "${el.accessibleName || 'none'}"`,
+    ],
+    5
+  );
+
+  logIssueList<TargetSizeIssue>(
+    'Possible Exceptions (Manual Review Recommended)',
+    excepted,
+    (el, i) => [
+      `${i + 1}. <${el.tagName}> "${el.selector}"`,
+      `   Size: ${el.width}x${el.height}px (min: ${el.minDimension}px)`,
+      `   Exception: ${el.exception} - ${el.exceptionDetails}`,
+    ],
+    5
+  );
+
+  const resolvedPath = saveAuditResult(result, {
+    ...location,
+    defaultFile: DEFAULT_TARGET_SIZE_RESULT_FILE,
+  });
+
+  let screenshotPath: string | undefined;
+  if (screenshot) {
+    // Build annotations for screenshot
+    const passSelectors = targets
+      .filter((t) => Math.min(t.width, t.height) >= aaaThreshold)
+      .map((t) => t.selector);
+
+    const annotations: AnnotationConfig[] = [
+      ...passSelectors.map((s) => ({
+        selector: s,
+        label: 'PASS',
+        colorScheme: 'pass' as const,
+      })),
+      ...failAAAOnly.map((t) => ({
+        selector: t.selector,
+        label: 'AA Pass',
+        colorScheme: 'warning' as const,
+      })),
+      ...failAA.map((t) => ({
+        selector: t.selector,
+        label: 'AA Fail',
+        colorScheme: 'fail' as const,
+      })),
+      ...excepted.map((t) => ({
+        selector: t.selector,
+        label: 'Exception',
+        colorScheme: 'info' as const,
+      })),
+    ];
+
+    await addPageAnnotations(page, annotations);
+    screenshotPath = await takeAuditScreenshot(page, {
+      path: resolveScreenshotPath(
+        resolvedPath,
+        DEFAULT_TARGET_SIZE_SCREENSHOT_FILE
+      ),
+    });
+
+    // Legend
+    console.log('\nLegend:');
+    console.log(`  PASS (green): >= ${aaaThreshold}px - AA Pass, AAA Pass`);
+    console.log(
+      `  AA Pass (orange): ${aaThreshold}-${aaaThreshold - 1}px - AA Pass, AAA Fail`
+    );
+    console.log(`  AA Fail (red): < ${aaThreshold}px - AA Fail, AAA Fail`);
+    console.log(`  Exception (blue): Possible exception (manual review needed)`);
+  }
+
+  logOutputPaths(resolvedPath, screenshotPath);
+
+  return result;
+}

--- a/packages/a11y-audit/src/schemas/index.ts
+++ b/packages/a11y-audit/src/schemas/index.ts
@@ -1,0 +1,285 @@
+/**
+ * Result types and JSON Schemas for the audit checks.
+ *
+ * The TypeScript types are the source of truth; the JSON Schemas are
+ * hand-written for consumers that validate the result files at runtime
+ * (e.g. an issue creator that reads `*-result.json`). They are intentionally
+ * permissive (no `additionalProperties: false`) so that additive changes to a
+ * result shape do not break downstream validation.
+ */
+
+export type {
+  AxeViolationNode,
+  AxeViolation,
+  AxeAuditResult,
+  FocusRecord,
+  OnFocusViolation,
+  FocusCheckResult,
+  BoundingRect,
+  FocusObscuredOverlap,
+  FocusObscuredIssue,
+  ReflowIssue,
+  ClippedTextElement,
+  ReflowCheckResult,
+  TargetSizeException,
+  TargetSizeIssue,
+  TargetSizeSummary,
+  TargetSizeCheckResult,
+} from '../types.js';
+
+/** Minimal JSON Schema object shape (Draft 2020-12 compatible subset). */
+export interface JsonSchema {
+  $schema?: string;
+  $id?: string;
+  title?: string;
+  type?: string | string[];
+  properties?: Record<string, JsonSchema>;
+  items?: JsonSchema;
+  required?: string[];
+  enum?: unknown[];
+  description?: string;
+  [key: string]: unknown;
+}
+
+const DISCLAIMER_SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: {
+    message: { type: 'string' },
+    messageEn: { type: 'string' },
+    coverage: { type: 'string' },
+    moreInfo: { type: 'string' },
+  },
+};
+
+export const AXE_AUDIT_RESULT_SCHEMA: JsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://masup9.github.io/a11y-audit/schemas/axe-audit-result.json',
+  title: 'AxeAuditResult',
+  type: 'object',
+  required: [
+    'url',
+    'timestamp',
+    'violations',
+    'passes',
+    'incomplete',
+    'inapplicable',
+    'violationCount',
+  ],
+  properties: {
+    url: { type: 'string' },
+    timestamp: { type: 'string' },
+    violations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['id', 'description', 'help', 'helpUrl', 'tags', 'nodes'],
+        properties: {
+          id: { type: 'string' },
+          impact: { type: ['string', 'null'] },
+          description: { type: 'string' },
+          help: { type: 'string' },
+          helpUrl: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+          nodes: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['html', 'target'],
+              properties: {
+                html: { type: 'string' },
+                target: { type: 'array', items: { type: 'string' } },
+                failureSummary: { type: ['string', 'null'] },
+              },
+            },
+          },
+        },
+      },
+    },
+    passes: { type: 'number' },
+    incomplete: { type: 'number' },
+    inapplicable: { type: 'number' },
+    violationCount: { type: 'number' },
+    disclaimer: DISCLAIMER_SCHEMA,
+  },
+};
+
+const FOCUS_ELEMENT_REF_SCHEMA: JsonSchema = {
+  type: 'object',
+  required: ['tag', 'name', 'selector'],
+  properties: {
+    tag: { type: 'string' },
+    role: { type: ['string', 'null'] },
+    name: { type: 'string' },
+    selector: { type: 'string' },
+  },
+};
+
+export const FOCUS_CHECK_RESULT_SCHEMA: JsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://masup9.github.io/a11y-audit/schemas/focus-check-result.json',
+  title: 'FocusCheckResult',
+  type: 'object',
+  required: [
+    'url',
+    'totalFocusableElements',
+    'elementsWithFocusStyle',
+    'elementsWithoutFocusStyle',
+    'issues',
+    'onFocusViolations',
+    'focusObscuredIssues',
+    'elementsWithObscuredFocus',
+    'allElements',
+    'interrupted',
+    'screenshotPath',
+  ],
+  properties: {
+    url: { type: 'string' },
+    totalFocusableElements: { type: 'number' },
+    elementsWithFocusStyle: { type: 'number' },
+    elementsWithoutFocusStyle: { type: 'number' },
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['tag', 'name'],
+        properties: {
+          tag: { type: 'string' },
+          role: { type: ['string', 'null'] },
+          name: { type: 'string' },
+        },
+      },
+    },
+    onFocusViolations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['element', 'fromUrl', 'toUrl', 'changeType'],
+        properties: {
+          element: FOCUS_ELEMENT_REF_SCHEMA,
+          fromUrl: { type: 'string' },
+          toUrl: { type: 'string' },
+          changeType: {
+            type: 'string',
+            enum: ['navigation', 'new-window', 'dialog'],
+          },
+        },
+      },
+    },
+    focusObscuredIssues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['element', 'elementRect', 'overlaps', 'obscuredRatio'],
+        properties: {
+          element: FOCUS_ELEMENT_REF_SCHEMA,
+          elementRect: { type: 'object' },
+          overlaps: { type: 'array', items: { type: 'object' } },
+          obscuredRatio: { type: 'number' },
+        },
+      },
+    },
+    elementsWithObscuredFocus: { type: 'number' },
+    allElements: { type: 'array', items: { type: 'object' } },
+    interrupted: { type: 'boolean' },
+    interruptedAt: { type: 'number' },
+    screenshotPath: { type: 'string' },
+    disclaimer: DISCLAIMER_SCHEMA,
+  },
+};
+
+export const REFLOW_CHECK_RESULT_SCHEMA: JsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://masup9.github.io/a11y-audit/schemas/reflow-check-result.json',
+  title: 'ReflowCheckResult',
+  type: 'object',
+  required: [
+    'url',
+    'viewport',
+    'hasHorizontalScroll',
+    'documentScrollWidth',
+    'documentClientWidth',
+    'overflowingElements',
+    'clippedTextElements',
+  ],
+  properties: {
+    url: { type: 'string' },
+    viewport: {
+      type: 'object',
+      required: ['width', 'height'],
+      properties: {
+        width: { type: 'number' },
+        height: { type: 'number' },
+      },
+    },
+    hasHorizontalScroll: { type: 'boolean' },
+    documentScrollWidth: { type: 'number' },
+    documentClientWidth: { type: 'number' },
+    overflowingElements: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['selector', 'tagName', 'rect', 'viewportWidth', 'reason'],
+        properties: {
+          selector: { type: 'string' },
+          tagName: { type: 'string' },
+          rect: { type: 'object' },
+          viewportWidth: { type: 'number' },
+          reason: {
+            type: 'string',
+            enum: ['overflow-right', 'overflow-left', 'clipped-text'],
+          },
+        },
+      },
+    },
+    clippedTextElements: { type: 'array', items: { type: 'object' } },
+    disclaimer: DISCLAIMER_SCHEMA,
+  },
+};
+
+export const TARGET_SIZE_CHECK_RESULT_SCHEMA: JsonSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://masup9.github.io/a11y-audit/schemas/target-size-check-result.json',
+  title: 'TargetSizeCheckResult',
+  type: 'object',
+  required: [
+    'url',
+    'totalTargetsChecked',
+    'failAA',
+    'failAAAOnly',
+    'passedTargets',
+    'exceptedTargets',
+    'summary',
+  ],
+  properties: {
+    url: { type: 'string' },
+    totalTargetsChecked: { type: 'number' },
+    failAA: { type: 'array', items: { type: 'object' } },
+    failAAAOnly: { type: 'array', items: { type: 'object' } },
+    passedTargets: { type: 'number' },
+    exceptedTargets: { type: 'array', items: { type: 'object' } },
+    summary: {
+      type: 'object',
+      required: [
+        'failAACount',
+        'failAAAOnlyCount',
+        'passCount',
+        'exceptedCount',
+      ],
+      properties: {
+        failAACount: { type: 'number' },
+        failAAAOnlyCount: { type: 'number' },
+        passCount: { type: 'number' },
+        exceptedCount: { type: 'number' },
+      },
+    },
+    disclaimer: DISCLAIMER_SCHEMA,
+  },
+};
+
+/** All result schemas keyed by check id. */
+export const RESULT_SCHEMAS = {
+  'axe-audit': AXE_AUDIT_RESULT_SCHEMA,
+  'focus-indicator-check': FOCUS_CHECK_RESULT_SCHEMA,
+  'reflow-check': REFLOW_CHECK_RESULT_SCHEMA,
+  'target-size-check': TARGET_SIZE_CHECK_RESULT_SCHEMA,
+} as const;

--- a/packages/a11y-audit/src/test-entries/axe-audit.ts
+++ b/packages/a11y-audit/src/test-entries/axe-audit.ts
@@ -1,0 +1,20 @@
+/**
+ * Compatibility test entry for the axe audit.
+ *
+ * Use via Playwright `testMatch`:
+ *   testMatch: ["**\/node_modules/@masup9/a11y-audit/dist/test-entries/*.js"]
+ *
+ * Target URL comes from the `TEST_PAGE` env var; output dir from
+ * `A11Y_OUTPUT_DIR` (falling back to cwd). This is a thin wrapper around
+ * `runAxeAudit` — all logic lives there.
+ */
+
+import { test } from '@playwright/test';
+import { runAxeAudit } from '../playwright/runAxeAudit.js';
+import { requireTargetUrl } from '../utils/test-harness.js';
+
+test('axe-core accessibility audit', async ({ page }) => {
+  const targetUrl = requireTargetUrl();
+  await page.goto(targetUrl, { waitUntil: 'networkidle' });
+  await runAxeAudit({ page });
+});

--- a/packages/a11y-audit/src/test-entries/axe-audit.ts
+++ b/packages/a11y-audit/src/test-entries/axe-audit.ts
@@ -4,7 +4,7 @@
  * Run it from a one-line local spec (Playwright excludes node_modules from
  * test collection, so a `testMatch` glob into node_modules finds nothing):
  *   // tests/a11y/axe.spec.ts
- *   import "@masup9/a11y-audit/test-entries/axe-audit";
+ *   import "@a11y-skills/audit/test-entries/axe-audit";
  *
  * Target URL comes from the `TEST_PAGE` env var; output dir from
  * `A11Y_OUTPUT_DIR` (falling back to cwd). This is a thin wrapper around

--- a/packages/a11y-audit/src/test-entries/axe-audit.ts
+++ b/packages/a11y-audit/src/test-entries/axe-audit.ts
@@ -1,8 +1,10 @@
 /**
  * Compatibility test entry for the axe audit.
  *
- * Use via Playwright `testMatch`:
- *   testMatch: ["**\/node_modules/@masup9/a11y-audit/dist/test-entries/*.js"]
+ * Run it from a one-line local spec (Playwright excludes node_modules from
+ * test collection, so a `testMatch` glob into node_modules finds nothing):
+ *   // tests/a11y/axe.spec.ts
+ *   import "@masup9/a11y-audit/test-entries/axe-audit";
  *
  * Target URL comes from the `TEST_PAGE` env var; output dir from
  * `A11Y_OUTPUT_DIR` (falling back to cwd). This is a thin wrapper around

--- a/packages/a11y-audit/src/test-entries/focus-indicator-check.ts
+++ b/packages/a11y-audit/src/test-entries/focus-indicator-check.ts
@@ -1,0 +1,15 @@
+/**
+ * Compatibility test entry for the focus indicator check
+ * (WCAG 2.4.7 / 2.4.12 / 3.2.1).
+ *
+ * Thin wrapper around `runFocusIndicatorCheck`. Target URL from `TEST_PAGE`,
+ * output dir from `A11Y_OUTPUT_DIR` (falling back to cwd). Captures the legacy
+ * screenshot. This check owns its browser context (see runFocusIndicatorCheck).
+ */
+
+import { test } from '@playwright/test';
+import { runFocusIndicatorCheck } from '../playwright/runFocusIndicatorCheck.js';
+
+test('focus indicator visibility', async ({ browser }) => {
+  await runFocusIndicatorCheck({ browser, screenshot: true });
+});

--- a/packages/a11y-audit/src/test-entries/reflow-check.ts
+++ b/packages/a11y-audit/src/test-entries/reflow-check.ts
@@ -1,0 +1,23 @@
+/**
+ * Compatibility test entry for the reflow check (WCAG 1.4.10).
+ *
+ * Thin wrapper around `runReflowCheck`. Target URL from `TEST_PAGE`,
+ * output dir from `A11Y_OUTPUT_DIR` (falling back to cwd). Sets the narrow
+ * viewport before navigation to match the legacy script behavior, and captures
+ * the legacy screenshot.
+ */
+
+import { test } from '@playwright/test';
+import { runReflowCheck } from '../playwright/runReflowCheck.js';
+import { requireTargetUrl } from '../utils/test-harness.js';
+import { REFLOW_VIEWPORT } from '../constants.js';
+
+test('reflow check (WCAG 1.4.10)', async ({ page }) => {
+  await page.setViewportSize({
+    width: REFLOW_VIEWPORT.width,
+    height: REFLOW_VIEWPORT.height,
+  });
+  const targetUrl = requireTargetUrl();
+  await page.goto(targetUrl, { waitUntil: 'networkidle' });
+  await runReflowCheck({ page, screenshot: true });
+});

--- a/packages/a11y-audit/src/test-entries/target-size-check.ts
+++ b/packages/a11y-audit/src/test-entries/target-size-check.ts
@@ -1,0 +1,17 @@
+/**
+ * Compatibility test entry for the target size check (WCAG 2.5.5 / 2.5.8).
+ *
+ * Thin wrapper around `runTargetSizeCheck`. Target URL from `TEST_PAGE`,
+ * output dir from `A11Y_OUTPUT_DIR` (falling back to cwd). Captures the legacy
+ * annotated screenshot.
+ */
+
+import { test } from '@playwright/test';
+import { runTargetSizeCheck } from '../playwright/runTargetSizeCheck.js';
+import { requireTargetUrl } from '../utils/test-harness.js';
+
+test('target size check (WCAG 2.5.5 / 2.5.8)', async ({ page }) => {
+  const targetUrl = requireTargetUrl();
+  await page.goto(targetUrl, { waitUntil: 'networkidle' });
+  await runTargetSizeCheck({ page, screenshot: true });
+});

--- a/packages/a11y-audit/src/types.ts
+++ b/packages/a11y-audit/src/types.ts
@@ -1,0 +1,254 @@
+/**
+ * Type definitions for the WCAG audit checks shipped in @masup9/a11y-audit.
+ */
+
+import type { AUDIT_DISCLAIMER } from './constants.js';
+
+// =============================================================================
+// Axe Audit Types (broad WCAG coverage)
+// =============================================================================
+
+export interface AxeViolationNode {
+  html: string;
+  target: string[];
+  failureSummary: string | undefined;
+}
+
+export interface AxeViolation {
+  id: string;
+  impact: string | null;
+  description: string;
+  help: string;
+  helpUrl: string;
+  tags: string[];
+  nodes: AxeViolationNode[];
+}
+
+export interface AxeAuditResult {
+  url: string;
+  timestamp: string;
+  violations: AxeViolation[];
+  passes: number;
+  incomplete: number;
+  inapplicable: number;
+  violationCount: number;
+  disclaimer: typeof AUDIT_DISCLAIMER;
+}
+
+// =============================================================================
+// Focus Indicator Types (WCAG 2.4.7)
+// =============================================================================
+
+export interface FocusRecord {
+  id: number;
+  tag: string;
+  role: string | null;
+  name: string;
+  hasFocusStyle: boolean;
+  diff: Record<string, string>;
+}
+
+/**
+ * WCAG 3.2.1 On Focus violation - context change triggered by focus
+ */
+export interface OnFocusViolation {
+  /** Element that triggered the navigation */
+  element: {
+    tag: string;
+    role: string | null;
+    name: string;
+    selector: string;
+  };
+  /** URL before focus */
+  fromUrl: string;
+  /** URL after focus (navigation target) */
+  toUrl: string;
+  /** Type of context change */
+  changeType: 'navigation' | 'new-window' | 'dialog';
+}
+
+export interface FocusCheckResult {
+  url: string;
+  totalFocusableElements: number;
+  elementsWithFocusStyle: number;
+  elementsWithoutFocusStyle: number;
+  /** WCAG 2.4.7 violations */
+  issues: Array<{
+    tag: string;
+    role: string | null;
+    name: string;
+  }>;
+  /** WCAG 3.2.1 violations - focus triggered context change */
+  onFocusViolations: OnFocusViolation[];
+  /** WCAG 2.4.12 violations - focus obscured by fixed/sticky elements */
+  focusObscuredIssues: FocusObscuredIssue[];
+  elementsWithObscuredFocus: number;
+  allElements: FocusRecord[];
+  /** Whether test was interrupted by navigation */
+  interrupted: boolean;
+  interruptedAt?: number;
+  /**
+   * Path the screenshot was (or would be) written to. Empty string when
+   * `screenshot` was disabled and no screenshot file was produced.
+   */
+  screenshotPath: string;
+}
+
+// =============================================================================
+// Focus Obscured Types (WCAG 2.4.12)
+// =============================================================================
+
+/**
+ * Bounding rect for overlap calculations
+ */
+export interface BoundingRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Information about an element obscuring the focused element
+ */
+export interface FocusObscuredOverlap {
+  /** The element causing the obscuring */
+  obscuredBy: {
+    tag: string;
+    role: string | null;
+    name: string;
+    selector: string;
+  };
+  /** The overlapping area */
+  overlapRect: BoundingRect;
+  /** Area of overlap in square pixels */
+  overlapArea: number;
+}
+
+/**
+ * WCAG 2.4.12 violation - focus indicator hidden by fixed/sticky content
+ */
+export interface FocusObscuredIssue {
+  /** The focused element that is obscured */
+  element: {
+    tag: string;
+    role: string | null;
+    name: string;
+    selector: string;
+  };
+  /** Bounding rect of the focused element */
+  elementRect: BoundingRect;
+  /** List of overlapping fixed/sticky elements */
+  overlaps: FocusObscuredOverlap[];
+  /** Ratio of element area that is obscured (0-1) */
+  obscuredRatio: number;
+}
+
+// =============================================================================
+// Reflow Check Types (WCAG 1.4.10)
+// =============================================================================
+
+export interface ReflowIssue {
+  selector: string;
+  tagName: string;
+  rect: {
+    left: number;
+    right: number;
+    width: number;
+  };
+  viewportWidth: number;
+  reason: 'overflow-right' | 'overflow-left' | 'clipped-text';
+}
+
+export interface ClippedTextElement {
+  selector: string;
+  tagName: string;
+  scrollWidth: number;
+  clientWidth: number;
+  scrollHeight: number;
+  clientHeight: number;
+  overflow: string;
+  overflowX: string;
+}
+
+export interface ReflowCheckResult {
+  url: string;
+  viewport: { width: number; height: number };
+  hasHorizontalScroll: boolean;
+  documentScrollWidth: number;
+  documentClientWidth: number;
+  overflowingElements: ReflowIssue[];
+  clippedTextElements: ClippedTextElement[];
+}
+
+// =============================================================================
+// Target Size Check Types (WCAG 2.5.5 / 2.5.8)
+// =============================================================================
+
+/**
+ * Exception types for WCAG 2.5.8 Target Size (Minimum)
+ * - inline: Target is in a sentence or text block
+ * - redundant: Another target with same function meets size requirement
+ * - ua-control: Size is determined by user agent (native controls)
+ * - spacing: Target has sufficient spacing from adjacent targets
+ * - essential-review: May be essential exception but requires manual review
+ */
+export type TargetSizeException =
+  | 'inline'
+  | 'redundant'
+  | 'ua-control'
+  | 'spacing'
+  | 'essential-review';
+
+export interface TargetSizeIssue {
+  /** CSS selector for the element */
+  selector: string;
+  /** HTML tag name */
+  tagName: string;
+  /** ARIA role if present */
+  role: string | null;
+  /** Computed accessible name */
+  accessibleName: string | null;
+  /** Element width in CSS pixels */
+  width: number;
+  /** Element height in CSS pixels */
+  height: number;
+  /** Smallest dimension (min of width/height) */
+  minDimension: number;
+  /** Pass/fail level */
+  level: 'fail-aa' | 'fail-aaa-only' | 'pass';
+  /** Exception that may apply */
+  exception: TargetSizeException | null;
+  /** Human-readable exception details */
+  exceptionDetails: string | null;
+  /** Link href for redundancy check */
+  href: string | null;
+}
+
+export interface TargetSizeSummary {
+  /** Number of targets failing AA (< 24px) */
+  failAACount: number;
+  /** Number of targets failing only AAA (24-43px) */
+  failAAAOnlyCount: number;
+  /** Number of targets passing (>= 44px) */
+  passCount: number;
+  /** Number of targets with possible exceptions */
+  exceptedCount: number;
+}
+
+export interface TargetSizeCheckResult {
+  /** Page URL */
+  url: string;
+  /** Total interactive elements checked */
+  totalTargetsChecked: number;
+  /** Elements failing AA threshold (< 24px) */
+  failAA: TargetSizeIssue[];
+  /** Elements failing only AAA threshold (24-43px) */
+  failAAAOnly: TargetSizeIssue[];
+  /** Number of elements passing (>= 44px) */
+  passedTargets: number;
+  /** Elements with possible exceptions */
+  exceptedTargets: TargetSizeIssue[];
+  /** Summary counts */
+  summary: TargetSizeSummary;
+}

--- a/packages/a11y-audit/src/types.ts
+++ b/packages/a11y-audit/src/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for the WCAG audit checks shipped in @masup9/a11y-audit.
+ * Type definitions for the WCAG audit checks shipped in @a11y-skills/audit.
  */
 
 import type { AUDIT_DISCLAIMER } from './constants.js';

--- a/packages/a11y-audit/src/utils/annotations.ts
+++ b/packages/a11y-audit/src/utils/annotations.ts
@@ -1,0 +1,138 @@
+/**
+ * Annotation overlay utilities for audit screenshots.
+ *
+ * Adds positioned boxes + labels over elements without modifying the content
+ * DOM. Used by the target size check to highlight pass/fail targets.
+ */
+
+// =============================================================================
+// Annotation Styles
+// =============================================================================
+
+/**
+ * Standard annotation color schemes.
+ * Colors chosen for sufficient contrast with white text.
+ */
+export const ANNOTATION_COLORS = {
+  /** Pass - Dark green with white text */
+  pass: { bg: '#16a34a', border: '#16a34a', text: '#ffffff' },
+  /** Warning - Dark orange with white text */
+  warning: { bg: '#e65100', border: '#e65100', text: '#ffffff' },
+  /** Fail - Dark red with white text */
+  fail: { bg: '#dc2626', border: '#dc2626', text: '#ffffff' },
+  /** Info - Dark blue with white text */
+  info: { bg: '#0d47a1', border: '#0d47a1', text: '#ffffff' },
+  /** Violation - Purple with white text */
+  violation: { bg: '#7c3aed', border: '#7c3aed', text: '#ffffff' },
+} as const;
+
+export type AnnotationColorScheme = keyof typeof ANNOTATION_COLORS;
+
+/**
+ * Annotation configuration for browser context.
+ */
+export interface AnnotationConfig {
+  /** CSS selector to annotate */
+  selector: string;
+  /** Label text to display */
+  label: string;
+  /** Color scheme to use */
+  colorScheme: AnnotationColorScheme;
+}
+
+// =============================================================================
+// Playwright Helper
+// =============================================================================
+
+/**
+ * Add annotations to a page using Playwright.
+ *
+ * Note: this mutates the page DOM (it appends an overlay element). Take any
+ * "clean" screenshot before calling this.
+ *
+ * @example
+ * await addPageAnnotations(page, [
+ *   { selector: '#header', label: 'PASS', colorScheme: 'pass' },
+ *   { selector: '.error', label: 'FAIL', colorScheme: 'fail' },
+ * ]);
+ */
+export async function addPageAnnotations(
+  page: import('@playwright/test').Page,
+  annotations: AnnotationConfig[]
+): Promise<void> {
+  await page.evaluate((configs) => {
+    // Inline the colors to avoid serialization issues
+    const colors = {
+      pass: { bg: '#16a34a', border: '#16a34a', text: '#ffffff' },
+      warning: { bg: '#e65100', border: '#e65100', text: '#ffffff' },
+      fail: { bg: '#dc2626', border: '#dc2626', text: '#ffffff' },
+      info: { bg: '#0d47a1', border: '#0d47a1', text: '#ffffff' },
+      violation: { bg: '#7c3aed', border: '#7c3aed', text: '#ffffff' },
+    };
+
+    // Create overlay
+    let overlay = document.getElementById(
+      'wcag-audit-overlay'
+    ) as HTMLDivElement | null;
+    if (!overlay) {
+      overlay = document.createElement('div');
+      overlay.id = 'wcag-audit-overlay';
+      overlay.style.cssText = `
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        z-index: 99999;
+      `;
+      document.body.appendChild(overlay);
+    }
+
+    // Add annotations
+    for (const config of configs) {
+      try {
+        const element = document.querySelector(config.selector);
+        if (!element) {
+          continue;
+        }
+
+        const rect = element.getBoundingClientRect();
+        const color = colors[config.colorScheme as keyof typeof colors];
+
+        const box = document.createElement('div');
+        box.style.cssText = `
+          position: absolute;
+          left: ${rect.left + window.scrollX}px;
+          top: ${rect.top + window.scrollY}px;
+          width: ${rect.width}px;
+          height: ${rect.height}px;
+          border: 3px solid ${color.border};
+          box-sizing: border-box;
+          pointer-events: none;
+        `;
+
+        const labelEl = document.createElement('span');
+        labelEl.textContent = config.label;
+        labelEl.style.cssText = `
+          position: absolute;
+          top: -22px;
+          left: -3px;
+          background: ${color.bg};
+          color: ${color.text};
+          font-size: 11px;
+          font-weight: bold;
+          padding: 2px 6px;
+          border-radius: 3px;
+          white-space: nowrap;
+          font-family: system-ui, sans-serif;
+        `;
+
+        box.appendChild(labelEl);
+        overlay.appendChild(box);
+      } catch {
+        // Ignore selector errors
+      }
+    }
+  }, annotations);
+}

--- a/packages/a11y-audit/src/utils/layout.ts
+++ b/packages/a11y-audit/src/utils/layout.ts
@@ -1,0 +1,192 @@
+/**
+ * Layout utilities for overflow and clipping detection.
+ * Used by the reflow check (and, in the future, zoom / text-spacing checks).
+ */
+
+import type { ReflowIssue, ClippedTextElement } from '../types.js';
+
+export interface LayoutCheckOptions {
+  viewportWidth: number;
+  overflowTolerance: number;
+  checkSelector: string;
+  allowedOverflowSelectors: readonly string[];
+}
+
+export interface LayoutCheckResult {
+  hasHorizontalScroll: boolean;
+  documentScrollWidth: number;
+  documentClientWidth: number;
+  overflowingElements: ReflowIssue[];
+  clippedTextElements: ClippedTextElement[];
+}
+
+/**
+ * Create the browser-side layout check function.
+ * This is serialized and executed in the browser context.
+ */
+export function createLayoutChecker(options: LayoutCheckOptions): LayoutCheckResult {
+  const {
+    viewportWidth,
+    overflowTolerance,
+    checkSelector,
+    allowedOverflowSelectors,
+  } = options;
+
+  // Helper functions (must be defined inside for browser context)
+  /**
+   * Generate a unique CSS selector for an element using index-based approach
+   * to avoid collisions with repeated components
+   */
+  function getUniqueSelector(element: Element, elementIndex: number): string {
+    if (element.id) {
+      return `#${element.id}`;
+    }
+
+    const path: string[] = [];
+    let current: Element | null = element;
+
+    while (current && current !== document.body) {
+      let selector = current.tagName.toLowerCase();
+
+      // Always use nth-child for uniqueness
+      const parent: Element | null = current.parentElement;
+      if (parent) {
+        const childIndex = Array.from(parent.children).indexOf(current) + 1;
+        selector += `:nth-child(${childIndex})`;
+      }
+
+      path.unshift(selector);
+      current = parent;
+    }
+
+    // Append element index as fallback for guaranteed uniqueness
+    return path.length > 0 ? path.join(' > ') : `[data-index="${elementIndex}"]`;
+  }
+
+  function isAllowedOverflow(element: Element): boolean {
+    return allowedOverflowSelectors.some((selector) => {
+      try {
+        return element.matches(selector) || element.closest(selector) !== null;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  function isVisible(element: Element): boolean {
+    const style = window.getComputedStyle(element);
+    return (
+      style.display !== 'none' &&
+      style.visibility !== 'hidden' &&
+      parseFloat(style.opacity) > 0
+    );
+  }
+
+  // Check document-level horizontal scroll
+  const scrollEl = document.scrollingElement || document.documentElement;
+  const documentScrollWidth = scrollEl.scrollWidth;
+  const documentClientWidth = scrollEl.clientWidth;
+  const hasHorizontalScroll =
+    documentScrollWidth > documentClientWidth + overflowTolerance;
+
+  // Find overflowing elements
+  const overflowingElements: ReflowIssue[] = [];
+  const clippedTextElements: ClippedTextElement[] = [];
+  // Use WeakSet to track elements by identity, not selector string
+  const seenElements = new WeakSet<Element>();
+
+  const elements = document.querySelectorAll(checkSelector);
+
+  elements.forEach((element, elementIndex) => {
+    if (!isVisible(element) || isAllowedOverflow(element)) {
+      return;
+    }
+
+    // Skip if we've already reported this element (by identity)
+    if (seenElements.has(element)) {
+      return;
+    }
+
+    const rect = element.getBoundingClientRect();
+    const selector = getUniqueSelector(element, elementIndex);
+
+    // Check for right overflow (element extends beyond viewport)
+    if (rect.right > viewportWidth + overflowTolerance) {
+      seenElements.add(element);
+      overflowingElements.push({
+        selector,
+        tagName: element.tagName.toLowerCase(),
+        rect: {
+          left: Math.round(rect.left),
+          right: Math.round(rect.right),
+          width: Math.round(rect.width),
+        },
+        viewportWidth,
+        reason: 'overflow-right',
+      });
+    }
+    // Check for left overflow (negative rect.left)
+    else if (rect.left < -overflowTolerance) {
+      seenElements.add(element);
+      overflowingElements.push({
+        selector,
+        tagName: element.tagName.toLowerCase(),
+        rect: {
+          left: Math.round(rect.left),
+          right: Math.round(rect.right),
+          width: Math.round(rect.width),
+        },
+        viewportWidth,
+        reason: 'overflow-left',
+      });
+    }
+
+    // Check for clipped text (element has overflow hidden and content is clipped)
+    const style = window.getComputedStyle(element);
+    const overflow = style.overflow;
+    const overflowX = style.overflowX;
+
+    const isClipped =
+      overflow === 'hidden' ||
+      overflow === 'clip' ||
+      overflowX === 'hidden' ||
+      overflowX === 'clip';
+
+    if (isClipped && !seenElements.has(element)) {
+      const scrollWidth = element.scrollWidth;
+      const clientWidth = element.clientWidth;
+      const scrollHeight = element.scrollHeight;
+      const clientHeight = element.clientHeight;
+
+      const hasHorizontalClip = scrollWidth > clientWidth + overflowTolerance;
+      const hasVerticalClip = scrollHeight > clientHeight + overflowTolerance;
+
+      if (hasHorizontalClip || hasVerticalClip) {
+        // Only report if element has text content
+        const hasText =
+          element.textContent && element.textContent.trim().length > 0;
+        if (hasText) {
+          seenElements.add(element);
+          clippedTextElements.push({
+            selector,
+            tagName: element.tagName.toLowerCase(),
+            scrollWidth,
+            clientWidth,
+            scrollHeight,
+            clientHeight,
+            overflow,
+            overflowX,
+          });
+        }
+      }
+    }
+  });
+
+  return {
+    hasHorizontalScroll,
+    documentScrollWidth,
+    documentClientWidth,
+    overflowingElements,
+    clippedTextElements,
+  };
+}

--- a/packages/a11y-audit/src/utils/test-harness.ts
+++ b/packages/a11y-audit/src/utils/test-harness.ts
@@ -57,10 +57,10 @@ export function resolveOutputPath(
     return path.resolve(outputPath);
   }
 
-  if (outputFile !== undefined && path.isAbsolute(outputFile)) {
+  if (outputFile !== undefined && path.basename(outputFile) !== outputFile) {
     throw new Error(
-      '`outputFile` must be a file name, not an absolute path. ' +
-        'Use `outputPath` to write to an absolute location.'
+      '`outputFile` must be a bare file name (no path separators or `..`). ' +
+        'Use `outputDir` for the directory, or `outputPath` for a full path.'
     );
   }
 

--- a/packages/a11y-audit/src/utils/test-harness.ts
+++ b/packages/a11y-audit/src/utils/test-harness.ts
@@ -1,0 +1,212 @@
+/**
+ * Test harness utilities for the audit checks.
+ *
+ * Provides output-path resolution (options → env → cwd), result writing, and
+ * console logging helpers shared by the four checks.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { Page } from '@playwright/test';
+import { AUDIT_DISCLAIMER, DISCLAIMER_CONSOLE } from '../constants.js';
+
+// =============================================================================
+// Output location resolution
+// =============================================================================
+
+/**
+ * Shared options for controlling where a check writes its result file.
+ *
+ * Resolution order:
+ *   1. `outputPath` (absolute or relative full path) — mutually exclusive with
+ *      `outputDir` / `outputFile`.
+ *   2. `outputDir` option → `A11Y_OUTPUT_DIR` env → `process.cwd()`, joined with
+ *      `outputFile` option → the check's default filename.
+ */
+export interface OutputLocationOptions {
+  /** Directory to write result/screenshot into. Falls back to `A11Y_OUTPUT_DIR`, then cwd. */
+  outputDir?: string;
+  /** Result file name (basename only). Falls back to the check's default. */
+  outputFile?: string;
+  /** Full path for the result file. Mutually exclusive with `outputDir`/`outputFile`. */
+  outputPath?: string;
+}
+
+/**
+ * Resolve the absolute path a check should write its result to.
+ *
+ * @throws if `outputPath` is combined with `outputDir`/`outputFile`, or if
+ *   `outputFile` is an absolute path.
+ */
+export function resolveOutputPath(
+  options: OutputLocationOptions & { defaultFile: string }
+): string {
+  const { outputDir, outputFile, outputPath, defaultFile } = options;
+
+  if (
+    outputPath !== undefined &&
+    (outputDir !== undefined || outputFile !== undefined)
+  ) {
+    throw new Error(
+      '`outputPath` cannot be combined with `outputDir` / `outputFile`. ' +
+        'Specify either `outputPath`, or `outputDir` + `outputFile`.'
+    );
+  }
+
+  if (outputPath !== undefined) {
+    return path.resolve(outputPath);
+  }
+
+  if (outputFile !== undefined && path.isAbsolute(outputFile)) {
+    throw new Error(
+      '`outputFile` must be a file name, not an absolute path. ' +
+        'Use `outputPath` to write to an absolute location.'
+    );
+  }
+
+  const dir = outputDir ?? process.env.A11Y_OUTPUT_DIR ?? process.cwd();
+  const file = outputFile ?? defaultFile;
+  return path.resolve(dir, file);
+}
+
+// =============================================================================
+// Result Output
+// =============================================================================
+
+export interface SaveResultOptions extends OutputLocationOptions {
+  /** Default file name when none is provided via options. */
+  defaultFile: string;
+  /** Whether to append the disclaimer to the written JSON (default: true). */
+  includeDisclaimer?: boolean;
+}
+
+/**
+ * Save an audit result to a JSON file, creating parent directories as needed.
+ *
+ * @returns the absolute path the result was written to.
+ */
+export function saveAuditResult<T extends object>(
+  result: T,
+  options: SaveResultOptions
+): string {
+  const { defaultFile, includeDisclaimer = true, ...location } = options;
+  const resolvedPath = resolveOutputPath({ ...location, defaultFile });
+
+  const outputData = includeDisclaimer
+    ? { ...result, disclaimer: AUDIT_DISCLAIMER }
+    : result;
+
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, JSON.stringify(outputData, null, 2));
+
+  return resolvedPath;
+}
+
+// =============================================================================
+// Screenshot Capture
+// =============================================================================
+
+export interface TakeScreenshotOptions {
+  /** Absolute or relative path to write the screenshot to. */
+  path: string;
+  /** Whether to capture the full page (default: true). */
+  fullPage?: boolean;
+}
+
+/**
+ * Take a screenshot with standard audit settings, creating parent dirs.
+ *
+ * @returns the absolute path the screenshot was written to.
+ */
+export async function takeAuditScreenshot(
+  page: Page,
+  options: TakeScreenshotOptions
+): Promise<string> {
+  const { path: screenshotPath, fullPage = true } = options;
+  const resolvedPath = path.resolve(screenshotPath);
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  await page.screenshot({ path: resolvedPath, fullPage });
+  return resolvedPath;
+}
+
+/**
+ * Resolve the screenshot path so it sits next to the resolved result file,
+ * using the given default screenshot filename when no explicit path is set.
+ */
+export function resolveScreenshotPath(
+  resolvedResultPath: string,
+  defaultScreenshotFile: string
+): string {
+  return path.join(path.dirname(resolvedResultPath), defaultScreenshotFile);
+}
+
+// =============================================================================
+// URL resolution (used by compatibility test-entries)
+// =============================================================================
+
+/**
+ * Resolve the target URL from an explicit value or the `TEST_PAGE` env var.
+ *
+ * @throws if neither is provided.
+ */
+export function requireTargetUrl(explicit?: string): string {
+  const url = explicit ?? process.env.TEST_PAGE;
+  if (!url) {
+    throw new Error(
+      'No target URL provided. Pass `targetUrl` or set the TEST_PAGE environment variable.'
+    );
+  }
+  return url;
+}
+
+// =============================================================================
+// Console Logging
+// =============================================================================
+
+/** Log the header for audit results to console. */
+export function logAuditHeader(title: string, wcagRef: string, url: string): void {
+  console.log(`\n=== ${title} (${wcagRef}) ===`);
+  console.log(`URL: ${url}`);
+}
+
+/** Log a summary section with key-value pairs. */
+export function logSummary(
+  items: Record<string, string | number | boolean>
+): void {
+  for (const [label, value] of Object.entries(items)) {
+    const displayValue =
+      typeof value === 'boolean' ? (value ? 'YES' : 'No') : value;
+    console.log(`${label}: ${displayValue}`);
+  }
+}
+
+/** Log a list of issues with truncation. */
+export function logIssueList<T>(
+  title: string,
+  items: T[],
+  formatter: (item: T, index: number) => string[],
+  maxItems = 10
+): void {
+  if (items.length === 0) {
+    return;
+  }
+
+  console.log(`\n--- ${title} ---`);
+  items.slice(0, maxItems).forEach((item, index) => {
+    const lines = formatter(item, index);
+    lines.forEach((line) => console.log(`  ${line}`));
+  });
+
+  if (items.length > maxItems) {
+    console.log(`  ... and ${items.length - maxItems} more`);
+  }
+}
+
+/** Log the output file paths and disclaimer. */
+export function logOutputPaths(outputPath: string, screenshotPath?: string): void {
+  console.log(`\nResults saved to: ${outputPath}`);
+  if (screenshotPath) {
+    console.log(`Screenshot saved to: ${screenshotPath}`);
+  }
+  console.log(DISCLAIMER_CONSOLE);
+}

--- a/packages/a11y-audit/test/parity.spec.ts
+++ b/packages/a11y-audit/test/parity.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Drift guard between the ported package functions and the original skill
+ * vendor scripts.
+ *
+ * Until Block B replaces the skill scripts with thin wrappers around this
+ * package (after 1.0.0), the same check logic lives in two places:
+ *   - skills/auditing-wcag/references/scripts/*.ts  (skill, canonical for now)
+ *   - packages/a11y-audit/src/**                    (this package)
+ *
+ * This test runs both against an identical fixture and asserts the written
+ * result JSON matches, so the two copies cannot silently diverge. PLAN scopes
+ * the minimum parity coverage to axe + reflow.
+ *
+ * The package side imports the BUILT dist (pretest builds it). The skill side
+ * is run as a subprocess via the skill's own Playwright config.
+ */
+
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runAxeAudit, runReflowCheck } from '../dist/playwright/index.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.resolve(here, '..');
+const repoRoot = path.resolve(packageDir, '..', '..');
+const skillScriptsDir = path.join(
+  repoRoot,
+  'skills',
+  'auditing-wcag',
+  'references',
+  'scripts'
+);
+
+const PARITY_FIXTURE = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>parity fixture</title>
+<style>
+  body { margin: 0; }
+  .wide { width: 1200px; height: 80px; background: #c00; }
+  .tiny { width: 10px; height: 10px; padding: 0; border: 0; }
+</style></head>
+<body>
+  <img src="missing.png">
+  <a href="#"></a>
+  <input type="text">
+  <div class="wide">A very wide block that cannot fit into a 320px viewport.</div>
+  <button id="b1" class="tiny">a</button><button id="b2" class="tiny">b</button>
+</body></html>`;
+
+const FIXTURE_URL = 'data:text/html,' + encodeURIComponent(PARITY_FIXTURE);
+
+/** Drop volatile fields so two runs of the same logic compare equal. */
+function normalize(result: Record<string, unknown>): Record<string, unknown> {
+  const clone = JSON.parse(JSON.stringify(result));
+  delete clone.timestamp; // axe stamps wall-clock time
+  delete clone.screenshotPath; // absolute path, run-specific (not in axe/reflow)
+  return clone;
+}
+
+/** Run a single skill check as a subprocess and return its written result JSON. */
+function runSkillCheck(testFile: string, resultFile: string): Record<string, unknown> {
+  const resultPath = path.join(skillScriptsDir, resultFile);
+  if (fs.existsSync(resultPath)) fs.rmSync(resultPath);
+  try {
+    execFileSync('npx', ['playwright', 'test', testFile], {
+      cwd: skillScriptsDir,
+      env: { ...process.env, TEST_PAGE: FIXTURE_URL },
+      stdio: 'pipe',
+    });
+  } catch (e) {
+    const err = e as { stdout?: Buffer; stderr?: Buffer };
+    throw new Error(
+      `skill ${testFile} failed:\n${err.stdout?.toString() ?? ''}\n${err.stderr?.toString() ?? ''}`
+    );
+  }
+  const json = JSON.parse(fs.readFileSync(resultPath, 'utf8'));
+  return json;
+}
+
+test.describe('parity: package functions vs skill vendor scripts', () => {
+  // The skill side runs as a subprocess using the skill's own Playwright
+  // install. Skip locally when those deps aren't present; CI installs them.
+  test.skip(
+    !fs.existsSync(path.join(skillScriptsDir, 'node_modules')),
+    'skill script deps not installed (run `npm ci` in the skill scripts dir)'
+  );
+
+  test('axe audit produces identical result JSON', async ({ page }, testInfo) => {
+    // Package side: write to a temp dir, then read the written file.
+    await page.goto(FIXTURE_URL, { waitUntil: 'networkidle' });
+    await runAxeAudit({ page, outputDir: testInfo.outputDir });
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(testInfo.outputDir, 'axe-result.json'), 'utf8')
+    );
+
+    // Skill side: subprocess.
+    const skill = runSkillCheck('axe-audit.ts', 'axe-result.json');
+
+    expect(normalize(pkg)).toEqual(normalize(skill));
+  });
+
+  test('reflow check produces identical result JSON', async ({ page }, testInfo) => {
+    // Match the skill's ordering (narrow viewport before navigation).
+    await page.setViewportSize({ width: 320, height: 256 });
+    await page.goto(FIXTURE_URL, { waitUntil: 'networkidle' });
+    await runReflowCheck({ page, outputDir: testInfo.outputDir });
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(testInfo.outputDir, 'reflow-result.json'), 'utf8')
+    );
+
+    const skill = runSkillCheck('reflow-check.ts', 'reflow-result.json');
+
+    expect(normalize(pkg)).toEqual(normalize(skill));
+  });
+});

--- a/packages/a11y-audit/test/smoke.spec.ts
+++ b/packages/a11y-audit/test/smoke.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Smoke tests for @masup9/a11y-audit.
+ *
+ * These import from the BUILT `dist/` output (run `npm run build` first; the
+ * `pretest` script does this automatically) so they exercise the actual
+ * published artifact. Each fixture is crafted to trigger the relevant check.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  runAxeAudit,
+  runReflowCheck,
+  runTargetSizeCheck,
+  runFocusIndicatorCheck,
+} from '../dist/playwright/index.js';
+
+const AXE_FIXTURE = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>axe fixture</title></head>
+<body>
+  <img src="missing.png">
+  <a href="#"></a>
+  <input type="text">
+</body></html>`;
+
+const REFLOW_FIXTURE = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>reflow fixture</title>
+<style>
+  body { margin: 0; }
+  .wide { width: 1200px; height: 80px; background: #c00; }
+</style></head>
+<body>
+  <div class="wide">A very wide block that cannot fit into a 320px viewport.</div>
+</body></html>`;
+
+const TARGET_FIXTURE = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>target fixture</title>
+<style>
+  body { margin: 0; }
+  .tiny { width: 10px; height: 10px; padding: 0; border: 0; font-size: 6px; }
+</style></head>
+<body>
+  <button id="b1" class="tiny">a</button><button id="b2" class="tiny">b</button>
+</body></html>`;
+
+const FOCUS_FIXTURE = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>focus fixture</title>
+<style>
+  button:focus { outline: none; }
+</style></head>
+<body>
+  <button id="nofocus">no focus indicator</button>
+</body></html>`;
+
+test('runAxeAudit detects violations', async ({ page }, testInfo) => {
+  await page.setContent(AXE_FIXTURE);
+  const result = await runAxeAudit({ page, outputDir: testInfo.outputDir });
+
+  expect(result.violationCount).toBeGreaterThan(0);
+  // image-alt is a reliable, deterministic violation for the fixture above.
+  const ids = result.violations.map((v) => v.id);
+  expect(ids).toContain('image-alt');
+});
+
+test('runReflowCheck detects horizontal overflow at 320px', async ({
+  page,
+}, testInfo) => {
+  await page.setContent(REFLOW_FIXTURE);
+  const result = await runReflowCheck({ page, outputDir: testInfo.outputDir });
+
+  expect(result.viewport).toEqual({ width: 320, height: 256 });
+  expect(
+    result.hasHorizontalScroll || result.overflowingElements.length > 0
+  ).toBe(true);
+});
+
+test('runTargetSizeCheck flags undersized adjacent targets', async ({
+  page,
+}, testInfo) => {
+  await page.setContent(TARGET_FIXTURE);
+  const result = await runTargetSizeCheck({
+    page,
+    outputDir: testInfo.outputDir,
+  });
+
+  expect(result.totalTargetsChecked).toBeGreaterThanOrEqual(2);
+  expect(result.summary.failAACount).toBeGreaterThan(0);
+});
+
+test('runFocusIndicatorCheck flags missing focus indicator', async ({
+  browser,
+}, testInfo) => {
+  const targetUrl = 'data:text/html,' + encodeURIComponent(FOCUS_FIXTURE);
+  const result = await runFocusIndicatorCheck({
+    browser,
+    targetUrl,
+    outputDir: testInfo.outputDir,
+  });
+
+  expect(result.totalFocusableElements).toBeGreaterThan(0);
+  expect(result.elementsWithoutFocusStyle).toBeGreaterThan(0);
+});

--- a/packages/a11y-audit/test/smoke.spec.ts
+++ b/packages/a11y-audit/test/smoke.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Smoke tests for @masup9/a11y-audit.
+ * Smoke tests for @a11y-skills/audit.
  *
  * These import from the BUILT `dist/` output (run `npm run build` first; the
  * `pretest` script does this automatically) so they exercise the actual

--- a/packages/a11y-audit/tsconfig.json
+++ b/packages/a11y-audit/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/a11y-audit/tsconfig.json
+++ b/packages/a11y-audit/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "tsBuildInfoFile": "dist/.tsbuildinfo"
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "test"]

--- a/skills/auditing-wcag/references/scripts/NPM-PACKAGE-NOTE.md
+++ b/skills/auditing-wcag/references/scripts/NPM-PACKAGE-NOTE.md
@@ -1,0 +1,29 @@
+# Heads up: these scripts are being consolidated into `@masup9/a11y-audit`
+
+The four checks here — `axe-audit.ts`, `focus-indicator-check.ts`,
+`reflow-check.ts`, `target-size-check.ts` (plus `utils/`, `constants.ts`,
+`types.ts`) — have been ported into the npm package
+[`packages/a11y-audit`](../../../../packages/a11y-audit) (`@masup9/a11y-audit`).
+
+**Until that package reaches `1.0.0` and Block B replaces these scripts with
+thin wrappers, the same logic lives in two places.** Treat
+`packages/a11y-audit/src/**` as the place where new work should land.
+
+## If you change a check here
+
+Keep the behavior in sync with the package, or you will break the parity
+drift guard:
+
+- `packages/a11y-audit/test/parity.spec.ts` runs **both** copies against an
+  identical fixture and asserts the result JSON matches (currently axe +
+  reflow). CI runs it in the `a11y-audit-package` job.
+
+If a change is intentional and should diverge, update the package side too (or
+adjust the parity test) in the same PR.
+
+## Scope of the duplication
+
+- Ported (kept in sync): the 4 checks above + their utils/constants/types.
+- Not ported (skill-only, Phase 2): `text-spacing-check.ts`,
+  `zoom-200-check.ts`, `orientation-check.ts`, `autocomplete-audit.ts`,
+  `time-limit-detector.ts`, `auto-play-detection.ts`, `detectors/`.

--- a/skills/auditing-wcag/references/scripts/NPM-PACKAGE-NOTE.md
+++ b/skills/auditing-wcag/references/scripts/NPM-PACKAGE-NOTE.md
@@ -1,9 +1,9 @@
-# Heads up: these scripts are being consolidated into `@masup9/a11y-audit`
+# Heads up: these scripts are being consolidated into `@a11y-skills/audit`
 
 The four checks here — `axe-audit.ts`, `focus-indicator-check.ts`,
 `reflow-check.ts`, `target-size-check.ts` (plus `utils/`, `constants.ts`,
 `types.ts`) — have been ported into the npm package
-[`packages/a11y-audit`](../../../../packages/a11y-audit) (`@masup9/a11y-audit`).
+[`packages/a11y-audit`](../../../../packages/a11y-audit) (`@a11y-skills/audit`).
 
 **Until that package reaches `1.0.0` and Block B replaces these scripts with
 thin wrappers, the same logic lives in two places.** Treat

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}


### PR DESCRIPTION
## 概要

`PLAN-npm-publish.md` の **Block A** を実装。リポジトリを monorepo workspaces 化し、`auditing-wcag` skill の機能本体を新規 npm package `@a11y-skills/audit` (v0.1.0) として切り出した。F+C ハイブリッド配布（npm が機能本体、skill は orchestrator）の第一歩。

## 含まれるもの

- **monorepo bootstrap**: root `package.json` (workspaces) + `tsconfig.base.json` (strict ESM / NodeNext / `noUncheckedIndexedAccess`)。
- **`packages/a11y-audit/`**: 4 検査を関数 API として移植
  - `runAxeAudit` / `runReflowCheck` / `runTargetSizeCheck`（遷移済み `page` を受ける）
  - `runFocusIndicatorCheck`（`browser` + `targetUrl` を受け、自身の context を所有・close）
  - 互換 `test-entries/*`（薄い wrapper、ロジック二重化なし）、`schemas`（結果型 + JSON Schema）
- **下流改修の昇格**: `resolveOutputPath`（options 優先 → `A11Y_OUTPUT_DIR` env → cwd）、focus の strict TS fix。
- **build**: 素の `tsc`（bundler なし。`dist/test-entries/*.js` を個別 discoverable に保つため）。pixelmatch/pngjs は除外。
- **CI/release**: package の build/smoke/dry-run を CI に追加、tag `a11y-audit-v*` で publish する `release.yml`。

## 検証

- `npm -w @a11y-skills/audit build` 成功、smoke test 4本 pass（各検査が違反を検出）。
- `npm publish --dry-run`: 36ファイル・約34kB、`dist/` + README(en/ja) + CHANGELOG + package.json のみ。
- `npm pack` した tarball を消費プロジェクトに install → 全 subpath の型解決 OK。
- **重要**: Playwright は `node_modules` をテスト収集から除外するため、`testMatch` での node_modules 指定は動かない（PLAN の想定を訂正）。1行ローカル import spec が正式手順で、動作確認済み。README/docs 反映済み。
- Codex レビュー: **PASS**（path traversal / publish access / context cleanup の指摘を修正済み）。

## スコープ外（別タスク）

- 0.1.0 の npm publish（本 PR マージ/手動で実施）
- Block B（skill v2.0 wrapper 化）→ 1.0.0 公開後
- Phase 2 の残り 5 検査

🤖 Generated with [Claude Code](https://claude.com/claude-code)
