### PR TITLE
refactor(a11y-audit)!: unify all checks on the axe-style result envelope

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Accessibility specialist skills for Claude Code. WCAG 2.2 review, conformance auditing, and improvement planning tools.",
-    "version": "2.7.0"
+    "version": "2.8.0"
   },
   "plugins": [
     {
       "name": "a11y-specialist-skills",
       "description": "Accessibility skills: reviewing-a11y (WCAG reviews), auditing-wcag (conformance audits with automated scripts), planning-wcag-audit (audit planning), planning-a11y-improvement (maturity + roadmap).",
       "source": "./",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "author": {
         "name": "masuP9"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "a11y-specialist-skills",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Accessibility specialist skills for Claude Code. WCAG 2.2 review, conformance auditing, and improvement planning tools.",
   "author": {
     "name": "masuP9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,23 @@
         "@types/node": "*"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.11.4",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
@@ -74,6 +91,30 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -89,6 +130,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pixelmatch": {
       "version": "7.2.0",
@@ -145,6 +193,16 @@
         "node": ">=14.19.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -168,13 +226,14 @@
     },
     "packages/a11y-audit": {
       "name": "@a11y-skills/audit",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",
         "@playwright/test": "^1.50.0",
         "@types/node": "^22.10.0",
         "@types/pngjs": "^6.0.5",
+        "ajv": "^8.20.0",
         "typescript": "^5.6.0"
       },
       "engines": {

--- a/packages/a11y-audit/CHANGELOG.md
+++ b/packages/a11y-audit/CHANGELOG.md
@@ -3,6 +3,50 @@
 All notable changes to `@a11y-skills/audit` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.3.0
+
+**Breaking** — every check now returns (and saves) a single axe-style envelope
+instead of its own ad-hoc shape. The public API is not yet stable in `0.x`, so
+this lands as a minor release.
+
+### Changed (breaking)
+
+- All `runXxx()` functions return `AuditCheckResult<TDetails>`: findings are
+  normalized into `violations` / `incomplete` / `passes` / `inapplicable`
+  rule arrays (axe-style `id` / `impact` / `tags` / `helpUrl` / `nodes`), with
+  rule-level counts in `summary`. The former top-level fields (`issues`,
+  `failAA`, `overflowingElements`, `clippedElements`, ...) moved unchanged
+  under `details`.
+- Classification is conservative: only findings whose detection has no blind
+  spot and where no WCAG exception can apply are `violations`
+  (on-focus context change, text-spacing clipping, invalid autocomplete
+  tokens). Everything else — reflow/zoom overflow, meta refresh, orientation
+  lock, missing focus styles, undersized targets — lands in `incomplete`, the
+  manual-review queue.
+- Saved JSON files use the same envelope; the JSON Schemas were rewritten
+  accordingly (`$defs`-based shared envelope + per-check `details` schemas).
+  Pre-0.3.0 result files no longer validate.
+- `saveAuditResult()` no longer appends a disclaimer (the envelope carries it).
+- `runAxeAudit` builds the buckets from the raw axe results: violations and
+  incomplete keep their nodes, passes/inapplicable keep rule metadata only;
+  `details` records the execution configuration.
+
+### Added
+
+- `rule-registry.ts`: per-rule metadata (`sc`, accurate per-SC `wcag*` tags,
+  `impact`, `scope`, classification) — target size split into
+  `a11y-skills/target-size-minimum` (2.5.8 AA) and
+  `a11y-skills/target-size-enhanced` (2.5.5 AAA).
+- Pure normalization mappers (`normalize*`), `buildAuditResult()`, and the
+  opt-in `mergeNormalizedResults()` exported from the package root. The
+  buckets are re-derivable from a saved result's `details`.
+- Element-level evidence: detail records now carry `html` (outerHTML, capped
+  at `HTML_SNIPPET_MAX_LENGTH`) and `htmlTruncated`; focus issues gained
+  `selector`. `TargetSizeIssue.exceptionAssessment`
+  (`ruled-out`/`possible`/`not-assessed`) drives the violation promotion.
+- Tests: mapper unit tests, merge invariants, and ajv (draft 2020-12) schema
+  validation of the produced envelopes.
+
 ## 0.2.0
 
 Phase 2 checks added (additive). Still a `0.x` preview — the function API may

--- a/packages/a11y-audit/README.ja.md
+++ b/packages/a11y-audit/README.ja.md
@@ -67,7 +67,7 @@ test("axe audit", async ({ page }, testInfo) => {
     // outputFile: "axe-result.json", // 任意で上書き
     // tags: ["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"],
   });
-  expect(result.violationCount).toBe(0);
+  expect(result.summary.violationCount).toBe(0);
 });
 ```
 
@@ -86,7 +86,7 @@ test("focus indicators", async ({ browser }, testInfo) => {
     screenshot: true,                 // 既定: false
     // contextOptions: { locale: "ja-JP" }, // browser.newContext() に転送
   });
-  expect(result.elementsWithoutFocusStyle).toBe(0);
+  expect(result.details.elementsWithoutFocusStyle).toBe(0);
 });
 ```
 
@@ -135,6 +135,52 @@ TEST_PAGE=https://example.com A11Y_OUTPUT_DIR=./a11y-results npx playwright test
 > を `testMatch` に指定してもテストは見つかりません。上記の 1 行 re-export spec が
 > entry を実行する正式な方法です。
 
+## 結果形式
+
+すべての検査は同じ axe 風の envelope を返し、同じ形式で JSON に保存します:
+
+```ts
+interface AuditCheckResult<TDetails> {
+  source: CheckSource;            // 例: "reflow-check"
+  url: string;
+  timestamp: string;
+  violations: NormalizedRuleResult[];   // 確定した違反
+  incomplete: NormalizedRuleResult[];   // 要手動確認
+  passes: NormalizedRuleResult[];       // 実行して問題が見つからなかったルール
+  inapplicable: NormalizedRuleResult[]; // 検査対象がなかったルール
+  summary: { violationCount; incompleteCount; passCount; checkedNodes? };
+  details: TDetails;              // 検査固有の証跡（測定値・スクリーンショット等）
+  disclaimer: { ... };
+}
+```
+
+各ルール結果は axe と同じ形（`id` / `impact` / `description` / `help` /
+`helpUrl` / `tags` / `nodes[]`、`nodes[].target` / `html` / `htmlTruncated` /
+`failureSummary`）です。独自ルールは名前空間付き
+（`a11y-skills/focus-visible`、`a11y-skills/target-size-minimum` など）で、
+SC ごとに正確な WCAG バージョン・レベルタグ（`wcag2aa`、`wcag21aa`、
+`wcag22aa`、`wcag247` 形式の SC タグ）が付きます。
+
+**分類は保守的です。** 検出に死角がなく WCAG の例外が適用され得ない場合のみ
+`violations` に入ります（フォーカスによる文脈変化、テキストスペーシングの
+クリップ、autocomplete の不正トークン）。それ以外の検出 — reflow/zoom の
+オーバーフロー、meta refresh、画面方向ロック、フォーカススタイル欠如、
+小さすぎるターゲット — は `incomplete` に入ります。`incomplete` はノイズでは
+なく「要手動確認キュー」として扱ってください。
+
+同一ページに対する複数検査の結果を 1 つにまとめるには:
+
+```ts
+import { mergeNormalizedResults } from "@a11y-skills/audit";
+
+const merged = mergeNormalizedResults([axeResult, reflowResult, targetResult]);
+```
+
+`mergeNormalizedResults` は URL 不一致で例外を投げ、ノードを
+`target` + `failureSummary` で重複排除し、複数バケツに現れるルールは
+`violations > incomplete > passes > inapplicable` の優先順位で統合します。
+frame / shadow root 内の同一セレクタは区別しません。
+
 ## 結果型とスキーマ
 
 ```ts
@@ -142,8 +188,10 @@ import type { AxeAuditResult, FocusCheckResult } from "@a11y-skills/audit/schema
 import { RESULT_SCHEMAS } from "@a11y-skills/audit/schemas";
 ```
 
-`RESULT_SCHEMAS` は各検査 id に手書きの JSON Schema を対応付けており、`*-result.json`
-を実行時に検証できます。
+`RESULT_SCHEMAS` は各検査 id に手書きの JSON Schema（draft 2020-12）を
+対応付けており、`*-result.json` を実行時に検証できます。正規化マッパー
+（`normalize*`）と `buildAuditResult` はパッケージルートから export されて
+いるため、保存済み結果の `details` から 4 区分をいつでも再導出できます。
 
 ## ライセンス
 

--- a/packages/a11y-audit/README.md
+++ b/packages/a11y-audit/README.md
@@ -69,7 +69,7 @@ test("axe audit", async ({ page }, testInfo) => {
     // outputFile: "axe-result.json", // optional override
     // tags: ["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"],
   });
-  expect(result.violationCount).toBe(0);
+  expect(result.summary.violationCount).toBe(0);
 });
 ```
 
@@ -88,7 +88,7 @@ test("focus indicators", async ({ browser }, testInfo) => {
     screenshot: true,                 // default: false
     // contextOptions: { locale: "ja-JP" }, // forwarded to browser.newContext()
   });
-  expect(result.elementsWithoutFocusStyle).toBe(0);
+  expect(result.details.elementsWithoutFocusStyle).toBe(0);
 });
 ```
 
@@ -138,6 +138,52 @@ TEST_PAGE=https://example.com A11Y_OUTPUT_DIR=./a11y-results npx playwright test
 > `**/node_modules/@a11y-skills/audit/dist/test-entries/*.js` finds no tests.
 > The one-line re-export specs above are the supported way to run the entries.
 
+## Result format
+
+Every check returns — and saves as JSON — the same axe-style envelope:
+
+```ts
+interface AuditCheckResult<TDetails> {
+  source: CheckSource;            // e.g. "reflow-check"
+  url: string;
+  timestamp: string;
+  violations: NormalizedRuleResult[];   // confirmed findings
+  incomplete: NormalizedRuleResult[];   // needs manual review
+  passes: NormalizedRuleResult[];       // rules that ran and found nothing
+  inapplicable: NormalizedRuleResult[]; // nothing to examine
+  summary: { violationCount; incompleteCount; passCount; checkedNodes? };
+  details: TDetails;              // check-specific evidence (measurements, screenshots, ...)
+  disclaimer: { ... };
+}
+```
+
+Each rule result is axe-shaped (`id` / `impact` / `description` / `help` /
+`helpUrl` / `tags` / `nodes[]`, with `nodes[].target` / `html` /
+`htmlTruncated` / `failureSummary`). Custom rules are namespaced
+(`a11y-skills/focus-visible`, `a11y-skills/target-size-minimum`, ...) and
+tagged with accurate WCAG version/level tags (`wcag2aa`, `wcag21aa`,
+`wcag22aa`, `wcag247`-style SC tags).
+
+**Classification is conservative.** A finding lands in `violations` only when
+the detection has no blind spot and no WCAG exception can apply (on-focus
+context change, text-spacing clipping, invalid autocomplete tokens). All other
+detections — reflow/zoom overflow, meta refresh, orientation lock, missing
+focus styles, undersized targets — are `incomplete`: treat that bucket as the
+manual-review queue, not as noise.
+
+To combine several checks for the same page into one view:
+
+```ts
+import { mergeNormalizedResults } from "@a11y-skills/audit";
+
+const merged = mergeNormalizedResults([axeResult, reflowResult, targetResult]);
+```
+
+`mergeNormalizedResults` throws on URL mismatches, deduplicates nodes by
+`target` + `failureSummary`, and resolves a rule appearing in several buckets
+by priority (`violations > incomplete > passes > inapplicable`). Identical
+selectors inside different frames or shadow roots are not distinguished.
+
 ## Result types & schemas
 
 ```ts
@@ -145,8 +191,11 @@ import type { AxeAuditResult, FocusCheckResult } from "@a11y-skills/audit/schema
 import { RESULT_SCHEMAS } from "@a11y-skills/audit/schemas";
 ```
 
-`RESULT_SCHEMAS` maps each check id to a hand-written JSON Schema for validating
-the `*-result.json` files at runtime.
+`RESULT_SCHEMAS` maps each check id to a hand-written JSON Schema
+(draft 2020-12) for validating the `*-result.json` files at runtime. The
+normalization mappers (`normalize*`) and `buildAuditResult` are exported from
+the package root, so the buckets can be re-derived from a saved result's
+`details` at any time.
 
 ## License
 

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a11y-skills/audit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Playwright + axe-core based WCAG 2.2 accessibility audit functions (axe, focus indicator, reflow, target size, text spacing, zoom, orientation, autocomplete, time limit, auto-play).",
   "type": "module",
   "license": "MIT",
@@ -113,6 +113,7 @@
     "@playwright/test": "^1.50.0",
     "@types/node": "^22.10.0",
     "@types/pngjs": "^6.0.5",
+    "ajv": "^8.20.0",
     "typescript": "^5.6.0"
   },
   "engines": {

--- a/packages/a11y-audit/src/constants.ts
+++ b/packages/a11y-audit/src/constants.ts
@@ -27,6 +27,13 @@ Note: Automated testing detects only ~30-40% of WCAG issues.
 `;
 
 // =============================================================================
+// Normalized result format
+// =============================================================================
+
+/** Maximum length of `NormalizedNode.html` / detail `html` snippets. */
+export const HTML_SNIPPET_MAX_LENGTH = 300;
+
+// =============================================================================
 // Axe Audit defaults (broad WCAG coverage)
 // =============================================================================
 

--- a/packages/a11y-audit/src/index.ts
+++ b/packages/a11y-audit/src/index.ts
@@ -14,7 +14,27 @@ export * from './types.js';
 export {
   AUDIT_DISCLAIMER,
   DEFAULT_AXE_TAGS,
+  HTML_SNIPPET_MAX_LENGTH,
   REFLOW_VIEWPORT,
   TARGET_SIZE_AA,
   TARGET_SIZE_AAA,
 } from './constants.js';
+export { RULES, getRule, type RuleKey, type RuleMeta } from './utils/rule-registry.js';
+export {
+  buildAuditResult,
+  mergeNormalizedResults,
+  normalizeAxeResults,
+  normalizeAutocompleteAudit,
+  normalizeAutoPlayDetection,
+  normalizeFocusCheck,
+  normalizeOrientationCheck,
+  normalizeReflowCheck,
+  normalizeTargetSizeCheck,
+  normalizeTextSpacingCheck,
+  normalizeTimeLimitDetector,
+  normalizeZoomCheck,
+  type MergedAuditResult,
+  type NormalizedBuckets,
+  type RawAxeResults,
+  type RawAxeRule,
+} from './utils/axe-format.js';

--- a/packages/a11y-audit/src/playwright/runAutoPlayDetection.ts
+++ b/packages/a11y-audit/src/playwright/runAutoPlayDetection.ts
@@ -20,6 +20,7 @@ import type {
   ScreenshotRecord,
   ComparisonResult,
   AutoPlayDetectionResult,
+  AutoPlayDetectionDetails,
 } from '../types.js';
 import {
   SCREENSHOT_INTERVALS,
@@ -27,6 +28,10 @@ import {
   DEFAULT_AUTO_PLAY_OUTPUT_DIR,
   DETECTION_RESULT_FILENAME,
 } from '../constants.js';
+import {
+  buildAuditResult,
+  normalizeAutoPlayDetection,
+} from '../utils/axe-format.js';
 import { generateRecommendation, printSummary } from '../utils/recommendations.js';
 
 /** Capture screenshots at configured intervals. */
@@ -180,8 +185,7 @@ export async function runAutoPlayDetection(
     pauseVerification = createSkippedVerification(reason);
   }
 
-  const result: AutoPlayDetectionResult = {
-    url: page.url(),
+  const details: AutoPlayDetectionDetails = {
     screenshotRecords: screenshots,
     comparisons,
     hasAutoPlayContent: hasAnyChange,
@@ -195,6 +199,13 @@ export async function runAutoPlayDetection(
       pauseVerification,
     }),
   };
+
+  const result: AutoPlayDetectionResult = buildAuditResult({
+    source: 'auto-play-detection',
+    url: page.url(),
+    details,
+    buckets: normalizeAutoPlayDetection(details),
+  });
 
   console.log('\n=== Auto-play Detection Results ===\n');
   console.log(JSON.stringify(result, null, 2));

--- a/packages/a11y-audit/src/playwright/runAutocompleteAudit.ts
+++ b/packages/a11y-audit/src/playwright/runAutocompleteAudit.ts
@@ -15,12 +15,21 @@
  */
 
 import type { Page } from '@playwright/test';
-import type { AutocompleteAuditResult, AutocompleteIssue } from '../types.js';
+import type {
+  AutocompleteAuditResult,
+  AutocompleteAuditDetails,
+  AutocompleteIssue,
+} from '../types.js';
 import {
   AUTOCOMPLETE_FIELD_PATTERNS,
   VALID_AUTOCOMPLETE_TOKENS,
   DEFAULT_AUTOCOMPLETE_RESULT_FILE,
+  HTML_SNIPPET_MAX_LENGTH,
 } from '../constants.js';
+import {
+  buildAuditResult,
+  normalizeAutocompleteAudit,
+} from '../utils/axe-format.js';
 import {
   saveAuditResult,
   logAuditHeader,
@@ -33,6 +42,8 @@ import {
 interface FieldInfo {
   selector: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   inputType: string;
   name: string | null;
   id: string | null;
@@ -45,6 +56,8 @@ interface FieldInfo {
 interface BasicFieldInfo {
   selector: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   inputType: string;
   name: string | null;
   id: string | null;
@@ -56,7 +69,27 @@ interface BasicFieldInfo {
  * Collect basic form field information in browser context.
  * Accessible names are retrieved separately via ariaSnapshot().
  */
-function collectBasicFieldInfo(): BasicFieldInfo[] {
+function collectBasicFieldInfo(args: {
+  htmlSnippetMaxLength: number;
+}): BasicFieldInfo[] {
+  const { htmlSnippetMaxLength } = args;
+
+  function getHtmlSnippet(element: Element): { html: string; htmlTruncated: boolean } {
+    let html = '';
+    try {
+      html = element.outerHTML || '';
+    } catch {
+      html = '';
+    }
+    if (!html) {
+      return { html: `<${element.tagName.toLowerCase()}>`, htmlTruncated: false };
+    }
+    if (html.length > htmlSnippetMaxLength) {
+      return { html: html.slice(0, htmlSnippetMaxLength), htmlTruncated: true };
+    }
+    return { html, htmlTruncated: false };
+  }
+
   function getUniqueSelector(element: Element, elementIndex: number): string {
     if (element.id) {
       return `#${element.id}`;
@@ -97,6 +130,7 @@ function collectBasicFieldInfo(): BasicFieldInfo[] {
     fields.push({
       selector: getUniqueSelector(element, index),
       tagName: el.tagName.toLowerCase(),
+      ...getHtmlSnippet(element),
       inputType,
       name: el.name || null,
       id: el.id || null,
@@ -168,6 +202,8 @@ function analyzeFields(
       missing.push({
         selector: field.selector,
         tagName: field.tagName,
+        html: field.html,
+        htmlTruncated: field.htmlTruncated,
         inputType: field.inputType,
         name: field.name,
         id: field.id,
@@ -190,6 +226,8 @@ function analyzeFields(
       invalid.push({
         selector: field.selector,
         tagName: field.tagName,
+        html: field.html,
+        htmlTruncated: field.htmlTruncated,
         inputType: field.inputType,
         name: field.name,
         id: field.id,
@@ -220,7 +258,9 @@ export async function runAutocompleteAudit(
   const { page, ...location } = options;
 
   // Collect basic field info from DOM
-  const basicFields = await page.evaluate(collectBasicFieldInfo);
+  const basicFields = await page.evaluate(collectBasicFieldInfo, {
+    htmlSnippetMaxLength: HTML_SNIPPET_MAX_LENGTH,
+  });
 
   // Enhance with accessible names via ariaSnapshot()
   const fields: FieldInfo[] = [];
@@ -251,25 +291,31 @@ export async function runAutocompleteAudit(
     VALID_AUTOCOMPLETE_TOKENS
   );
 
-  const result: AutocompleteAuditResult = {
-    url: page.url(),
+  const details: AutocompleteAuditDetails = {
     totalFieldsChecked: fields.length,
     missingAutocomplete: missing,
     invalidAutocomplete: invalid,
   };
 
+  const result: AutocompleteAuditResult = buildAuditResult({
+    source: 'autocomplete-audit',
+    url: page.url(),
+    details,
+    buckets: normalizeAutocompleteAudit(details),
+  });
+
   // Output results
   logAuditHeader('Autocomplete Audit Results', 'WCAG 1.3.5', result.url);
 
   logSummary({
-    'Total form fields': result.totalFieldsChecked,
-    'Fields missing autocomplete': result.missingAutocomplete.length,
-    'Fields with invalid autocomplete': result.invalidAutocomplete.length,
+    'Total form fields': details.totalFieldsChecked,
+    'Fields missing autocomplete': details.missingAutocomplete.length,
+    'Fields with invalid autocomplete': details.invalidAutocomplete.length,
   });
 
   logIssueList<AutocompleteIssue>(
     'Missing Autocomplete',
-    result.missingAutocomplete,
+    details.missingAutocomplete,
     (el, i) => [
       `${i + 1}. <${el.tagName}> "${el.selector}"`,
       `   name: ${el.name || 'none'}, id: ${el.id || 'none'}`,
@@ -280,7 +326,7 @@ export async function runAutocompleteAudit(
 
   logIssueList<AutocompleteIssue>(
     'Invalid Autocomplete',
-    result.invalidAutocomplete,
+    details.invalidAutocomplete,
     (el, i) => [
       `${i + 1}. <${el.tagName}> "${el.selector}"`,
       `   Current: autocomplete="${el.currentAutocomplete}"`,

--- a/packages/a11y-audit/src/playwright/runAxeAudit.ts
+++ b/packages/a11y-audit/src/playwright/runAxeAudit.ts
@@ -5,18 +5,19 @@
  * caller is responsible for navigating the page (e.g. `await page.goto(url)`)
  * before calling this function.
  *
+ * The normalized buckets are built from the RAW axe results (violations and
+ * incomplete keep their nodes; passes/inapplicable keep rule metadata only),
+ * and `details` records the execution configuration.
+ *
  * Axe-core cannot detect all accessibility issues — manual testing and the
  * other checks in this package are still needed for complete coverage.
  */
 
 import { AxeBuilder } from '@axe-core/playwright';
 import type { Page } from '@playwright/test';
-import type { AxeAuditResult } from '../types.js';
-import {
-  AUDIT_DISCLAIMER,
-  DEFAULT_AXE_TAGS,
-  DEFAULT_AXE_RESULT_FILE,
-} from '../constants.js';
+import type { AxeAuditResult, AxeAuditDetails } from '../types.js';
+import { DEFAULT_AXE_TAGS, DEFAULT_AXE_RESULT_FILE } from '../constants.js';
+import { buildAuditResult, normalizeAxeResults } from '../utils/axe-format.js';
 import {
   saveAuditResult,
   logAuditHeader,
@@ -49,38 +50,32 @@ export async function runAxeAudit(
   }
   const axeResults = await builder.analyze();
 
-  const result: AxeAuditResult = {
-    url: page.url(),
-    timestamp: new Date().toISOString(),
-    violations: axeResults.violations.map((v) => ({
-      id: v.id,
-      impact: v.impact ?? null,
-      description: v.description,
-      help: v.help,
-      helpUrl: v.helpUrl,
-      tags: v.tags,
-      nodes: v.nodes.map((n) => ({
-        html: n.html,
-        target: n.target as string[],
-        failureSummary: n.failureSummary,
-      })),
-    })),
-    passes: axeResults.passes.length,
-    incomplete: axeResults.incomplete.length,
-    inapplicable: axeResults.inapplicable.length,
-    violationCount: axeResults.violations.length,
-    disclaimer: AUDIT_DISCLAIMER,
+  const buckets = normalizeAxeResults(axeResults);
+  const details: AxeAuditDetails = {
+    tagsRun: [...tags],
+    rulesOverride: rules ?? null,
+    violationRuleCount: axeResults.violations.length,
+    passRuleCount: axeResults.passes.length,
+    incompleteRuleCount: axeResults.incomplete.length,
+    inapplicableRuleCount: axeResults.inapplicable.length,
   };
+
+  const result = buildAuditResult({
+    source: 'axe-audit',
+    url: page.url(),
+    details,
+    buckets,
+  });
 
   // Output results
   logAuditHeader('Axe-core Accessibility Audit Results', 'axe-core', result.url);
 
   logSummary({
     Timestamp: result.timestamp,
-    Violations: result.violationCount,
-    Passes: result.passes,
-    'Incomplete (needs review)': result.incomplete,
-    Inapplicable: result.inapplicable,
+    Violations: result.summary.violationCount,
+    Passes: result.summary.passCount,
+    'Incomplete (needs review)': result.summary.incompleteCount,
+    Inapplicable: result.inapplicable.length,
   });
 
   if (result.violations.length > 0) {
@@ -108,7 +103,7 @@ export async function runAxeAudit(
   }
 
   console.log(`\n--- Summary ---`);
-  if (result.violationCount === 0) {
+  if (result.summary.violationCount === 0) {
     console.log('No violations detected by axe-core');
   } else {
     const totalElements = result.violations.reduce(
@@ -116,15 +111,13 @@ export async function runAxeAudit(
       0
     );
     console.log(
-      `Found ${result.violationCount} violation type(s) affecting ${totalElements} element(s)`
+      `Found ${result.summary.violationCount} violation type(s) affecting ${totalElements} element(s)`
     );
   }
 
-  // axe results already carry the disclaimer field; don't append it again.
   const resolvedPath = saveAuditResult(result, {
     ...location,
     defaultFile: DEFAULT_AXE_RESULT_FILE,
-    includeDisclaimer: false,
   });
   logOutputPaths(resolvedPath);
 

--- a/packages/a11y-audit/src/playwright/runFocusIndicatorCheck.ts
+++ b/packages/a11y-audit/src/playwright/runFocusIndicatorCheck.ts
@@ -19,8 +19,10 @@ import type {
 } from '@playwright/test';
 import type {
   FocusRecord,
+  FocusElementRef,
   OnFocusViolation,
   FocusCheckResult,
+  FocusCheckDetails,
   FocusObscuredIssue,
 } from '../types.js';
 import {
@@ -32,7 +34,9 @@ import {
   FOCUS_OBSCURED_MIN_OVERLAP_RATIO,
   FOCUS_OBSCURED_MIN_OVERLAP_PX,
   FOCUS_OBSCURED_EXCLUDE_SELECTORS,
+  HTML_SNIPPET_MAX_LENGTH,
 } from '../constants.js';
+import { buildAuditResult, normalizeFocusCheck } from '../utils/axe-format.js';
 import {
   resolveOutputPath,
   resolveScreenshotPath,
@@ -157,29 +161,23 @@ export async function runFocusIndicatorCheck(
       const page = await context.newPage();
 
       const focusHistory: FocusRecord[] = [];
-      let lastFocusedElement: {
-        tag: string;
-        role: string | null;
-        name: string;
-        selector: string;
-      } | null = null;
+      let lastFocusedElement: FocusElementRef | null = null;
       let navigationDetected = false;
 
       // Expose function to receive focus reports from browser context
-      await page.exposeFunction(
-        'reportFocus',
-        (data: FocusRecord & { selector?: string }) => {
-          focusHistory.push(data);
-          lastFocusedElement = {
-            tag: data.tag,
-            role: data.role,
-            name: data.name,
-            selector:
-              data.selector ||
-              `${data.tag.toLowerCase()}:nth-of-type(${data.id + 1})`,
-          };
-        }
-      );
+      await page.exposeFunction('reportFocus', (data: FocusRecord) => {
+        focusHistory.push(data);
+        lastFocusedElement = {
+          tag: data.tag,
+          role: data.role,
+          name: data.name,
+          selector:
+            data.selector ||
+            `${data.tag.toLowerCase()}:nth-of-type(${data.id + 1})`,
+          html: data.html,
+          htmlTruncated: data.htmlTruncated,
+        };
+      });
 
       // Expose function to receive focus obscured reports (WCAG 2.4.12)
       await page.exposeFunction(
@@ -195,6 +193,7 @@ export async function runFocusIndicatorCheck(
         styleProperties: [...FOCUS_STYLE_PROPERTIES],
         warningStyles: WARNING_STYLES,
         skipSelectors: [...skipSelectors],
+        htmlSnippetMaxLength: HTML_SNIPPET_MAX_LENGTH,
         obscuredConfig: {
           minOverlapRatio: FOCUS_OBSCURED_MIN_OVERLAP_RATIO,
           minOverlapPx: FOCUS_OBSCURED_MIN_OVERLAP_PX,
@@ -249,14 +248,9 @@ export async function runFocusIndicatorCheck(
         await page.keyboard.press('Tab');
 
         // Get currently focused element IMMEDIATELY after Tab
-        let currentFocusedElement: {
-          tag: string;
-          role: string | null;
-          name: string;
-          selector: string;
-        } | null = null;
+        let currentFocusedElement: FocusElementRef | null = null;
         try {
-          currentFocusedElement = await page.evaluate(() => {
+          currentFocusedElement = await page.evaluate((htmlSnippetMaxLength) => {
             const el = document.activeElement;
             if (!el || el === document.body) return null;
 
@@ -273,6 +267,17 @@ export async function runFocusIndicatorCheck(
               return `${getSelector(parent)} > ${tag}:nth-of-type(${index})`;
             };
 
+            let html = '';
+            try {
+              html = el.outerHTML || '';
+            } catch {
+              html = '';
+            }
+            if (!html) {
+              html = `<${el.tagName.toLowerCase()}>`;
+            }
+            const htmlTruncated = html.length > htmlSnippetMaxLength;
+
             return {
               tag: el.tagName,
               role: el.getAttribute('role'),
@@ -281,8 +286,10 @@ export async function runFocusIndicatorCheck(
                 el.textContent?.slice(0, 30) ||
                 '',
               selector: getSelector(el),
+              html: htmlTruncated ? html.slice(0, htmlSnippetMaxLength) : html,
+              htmlTruncated,
             };
-          });
+          }, HTML_SNIPPET_MAX_LENGTH);
         } catch {
           // Page might have navigated, use lastFocusedElement as fallback
           currentFocusedElement = lastFocusedElement;
@@ -361,8 +368,7 @@ export async function runFocusIndicatorCheck(
     }
 
     // Build result
-    const result: FocusCheckResult = {
-      url: finalPage.url(),
+    const details: FocusCheckDetails = {
       totalFocusableElements: finalFocusHistory.length,
       elementsWithFocusStyle:
         finalFocusHistory.length - elementsWithoutFocusStyle.length,
@@ -371,6 +377,9 @@ export async function runFocusIndicatorCheck(
         tag: el.tag,
         role: el.role,
         name: el.name,
+        selector: el.selector,
+        html: el.html,
+        htmlTruncated: el.htmlTruncated,
       })),
       onFocusViolations,
       focusObscuredIssues,
@@ -380,19 +389,26 @@ export async function runFocusIndicatorCheck(
       screenshotPath: screenshot ? resolvedScreenshotPath : '',
     };
 
+    const result: FocusCheckResult = buildAuditResult({
+      source: 'focus-indicator-check',
+      url: finalPage.url(),
+      details,
+      buckets: normalizeFocusCheck(details),
+    });
+
     // Output results
     logAuditHeader(
       'Focus Indicator Check Results',
-      'WCAG 2.4.7 / 2.4.12 / 3.2.1',
+      'WCAG 2.4.7 / 2.4.11 / 3.2.1',
       result.url
     );
 
-    console.log(`Total focusable elements: ${result.totalFocusableElements}`);
-    console.log(`Elements with focus style: ${result.elementsWithFocusStyle}`);
+    console.log(`Total focusable elements: ${details.totalFocusableElements}`);
+    console.log(`Elements with focus style: ${details.elementsWithFocusStyle}`);
     console.log(
-      `Elements WITHOUT focus style: ${result.elementsWithoutFocusStyle}`
+      `Elements WITHOUT focus style: ${details.elementsWithoutFocusStyle}`
     );
-    console.log(`Elements with OBSCURED focus: ${result.elementsWithObscuredFocus}`);
+    console.log(`Elements with OBSCURED focus: ${details.elementsWithObscuredFocus}`);
 
     if (retryCount > 0) {
       console.log(
@@ -469,14 +485,39 @@ function createFocusTrackerScript(args: {
   styleProperties: string[];
   warningStyles: string;
   skipSelectors: string[];
+  htmlSnippetMaxLength: number;
   obscuredConfig: {
     minOverlapRatio: number;
     minOverlapPx: number;
     excludeSelectors: string[];
   };
 }): void {
-  const { focusableSelector, styleProperties, warningStyles, skipSelectors, obscuredConfig } =
-    args;
+  const {
+    focusableSelector,
+    styleProperties,
+    warningStyles,
+    skipSelectors,
+    htmlSnippetMaxLength,
+    obscuredConfig,
+  } = args;
+
+  const getHtmlSnippet = (
+    el: Element
+  ): { html: string; htmlTruncated: boolean } => {
+    let html = '';
+    try {
+      html = el.outerHTML || '';
+    } catch {
+      html = '';
+    }
+    if (!html) {
+      return { html: `<${el.tagName.toLowerCase()}>`, htmlTruncated: false };
+    }
+    if (html.length > htmlSnippetMaxLength) {
+      return { html: html.slice(0, htmlSnippetMaxLength), htmlTruncated: true };
+    }
+    return { html, htmlTruncated: false };
+  };
 
   // Add warning styles
   const styleSheet = new CSSStyleSheet();
@@ -884,6 +925,7 @@ function createFocusTrackerScript(args: {
             focusedEl.textContent?.slice(0, 30) ||
             '',
           selector: getSelector(focusedEl),
+          ...getHtmlSnippet(focusedEl),
         },
         elementRect: {
           left: focusedRect.left,
@@ -966,10 +1008,11 @@ function createFocusTrackerScript(args: {
       id,
       tag: el.tagName,
       role: el.getAttribute('role'),
-      name: el.getAttribute('aria-label') || el.textContent?.slice(0, 30),
+      name: el.getAttribute('aria-label') || el.textContent?.slice(0, 30) || '',
       hasFocusStyle,
       diff,
       selector: elementSelectors.get(el) || getSelector(el),
+      ...getHtmlSnippet(el),
     });
 
     // Check for WCAG 2.4.12 - focus obscured by fixed/sticky elements

--- a/packages/a11y-audit/src/playwright/runOrientationCheck.ts
+++ b/packages/a11y-audit/src/playwright/runOrientationCheck.ts
@@ -17,7 +17,11 @@
  */
 
 import type { Page } from '@playwright/test';
-import type { OrientationCheckResult, OrientationState } from '../types.js';
+import type {
+  OrientationCheckResult,
+  OrientationCheckDetails,
+  OrientationState,
+} from '../types.js';
 import {
   ORIENTATION_VIEWPORTS,
   ORIENTATION_LOCK_KEYWORDS,
@@ -26,6 +30,10 @@ import {
   DEFAULT_ORIENTATION_PORTRAIT_SCREENSHOT_FILE,
   DEFAULT_ORIENTATION_LANDSCAPE_SCREENSHOT_FILE,
 } from '../constants.js';
+import {
+  buildAuditResult,
+  normalizeOrientationCheck,
+} from '../utils/axe-format.js';
 import {
   saveAuditResult,
   resolveOutputPath,
@@ -213,28 +221,34 @@ export async function runOrientationCheck(
   const hasOrientationLock = portraitHasLock || landscapeHasLock;
   const lockDetectedIn = determineLockLocation(portraitHasLock, landscapeHasLock);
 
-  const result: OrientationCheckResult = {
-    url: page.url(),
+  const details: OrientationCheckDetails = {
     portrait: portraitState,
     landscape: landscapeState,
     hasOrientationLock,
     lockDetectedIn,
   };
 
+  const result: OrientationCheckResult = buildAuditResult({
+    source: 'orientation-check',
+    url: page.url(),
+    details,
+    buckets: normalizeOrientationCheck(details),
+  });
+
   // Output results
   logAuditHeader('Orientation Check Results', 'WCAG 1.3.4', result.url);
-  logOrientationState('Portrait', ORIENTATION_VIEWPORTS.portrait, result.portrait);
+  logOrientationState('Portrait', ORIENTATION_VIEWPORTS.portrait, details.portrait);
   logOrientationState(
     'Landscape',
     ORIENTATION_VIEWPORTS.landscape,
-    result.landscape
+    details.landscape
   );
 
   console.log(
-    `\nOrientation lock detected: ${result.hasOrientationLock ? 'YES' : 'No'}`
+    `\nOrientation lock detected: ${details.hasOrientationLock ? 'YES' : 'No'}`
   );
-  if (result.hasOrientationLock) {
-    console.log(`Lock detected in: ${result.lockDetectedIn}`);
+  if (details.hasOrientationLock) {
+    console.log(`Lock detected in: ${details.lockDetectedIn}`);
   }
 
   const writtenPath = saveAuditResult(result, {

--- a/packages/a11y-audit/src/playwright/runReflowCheck.ts
+++ b/packages/a11y-audit/src/playwright/runReflowCheck.ts
@@ -17,6 +17,7 @@
 import type { Page } from '@playwright/test';
 import type {
   ReflowCheckResult,
+  ReflowCheckDetails,
   ReflowIssue,
   ClippedTextElement,
 } from '../types.js';
@@ -27,8 +28,10 @@ import {
   REFLOW_ALLOWED_OVERFLOW_SELECTORS,
   DEFAULT_REFLOW_RESULT_FILE,
   DEFAULT_REFLOW_SCREENSHOT_FILE,
+  HTML_SNIPPET_MAX_LENGTH,
 } from '../constants.js';
 import { createLayoutChecker } from '../utils/layout.js';
+import { buildAuditResult, normalizeReflowCheck } from '../utils/axe-format.js';
 import {
   saveAuditResult,
   takeAuditScreenshot,
@@ -73,29 +76,36 @@ export async function runReflowCheck(
     overflowTolerance,
     checkSelector: REFLOW_CHECK_SELECTOR,
     allowedOverflowSelectors: [...REFLOW_ALLOWED_OVERFLOW_SELECTORS],
+    htmlSnippetMaxLength: HTML_SNIPPET_MAX_LENGTH,
   });
 
-  const result: ReflowCheckResult = {
-    url: page.url(),
+  const details: ReflowCheckDetails = {
     viewport: { width: viewport.width, height: viewport.height },
     ...layoutResult,
   };
+
+  const result: ReflowCheckResult = buildAuditResult({
+    source: 'reflow-check',
+    url: page.url(),
+    details,
+    buckets: normalizeReflowCheck(details),
+  });
 
   // Output results
   logAuditHeader('Reflow Check Results', 'WCAG 1.4.10', result.url);
 
   logSummary({
-    Viewport: `${result.viewport.width}x${result.viewport.height}`,
-    'Document scroll width': `${result.documentScrollWidth}px`,
-    'Document client width': `${result.documentClientWidth}px`,
-    'Horizontal scroll': result.hasHorizontalScroll,
-    'Overflowing elements': result.overflowingElements.length,
-    'Clipped text elements': result.clippedTextElements.length,
+    Viewport: `${details.viewport.width}x${details.viewport.height}`,
+    'Document scroll width': `${details.documentScrollWidth}px`,
+    'Document client width': `${details.documentClientWidth}px`,
+    'Horizontal scroll': details.hasHorizontalScroll,
+    'Overflowing elements': details.overflowingElements.length,
+    'Clipped text elements': details.clippedTextElements.length,
   });
 
   logIssueList<ReflowIssue>(
     'Overflowing Elements',
-    result.overflowingElements,
+    details.overflowingElements,
     (el, i) => [
       `${i + 1}. <${el.tagName}> "${el.selector}"`,
       `   rect.right: ${el.rect.right}px (viewport: ${el.viewportWidth}px)`,
@@ -104,7 +114,7 @@ export async function runReflowCheck(
 
   logIssueList<ClippedTextElement>(
     'Clipped Text Elements',
-    result.clippedTextElements,
+    details.clippedTextElements,
     (el, i) => [
       `${i + 1}. <${el.tagName}> "${el.selector}"`,
       `   scrollWidth: ${el.scrollWidth}px, clientWidth: ${el.clientWidth}px`,

--- a/packages/a11y-audit/src/playwright/runTargetSizeCheck.ts
+++ b/packages/a11y-audit/src/playwright/runTargetSizeCheck.ts
@@ -20,6 +20,7 @@ import type { Page } from '@playwright/test';
 import type {
   TargetSizeIssue,
   TargetSizeCheckResult,
+  TargetSizeCheckDetails,
   TargetSizeException,
 } from '../types.js';
 import {
@@ -31,7 +32,12 @@ import {
   INLINE_CONTEXT_MIN_TEXT,
   DEFAULT_TARGET_SIZE_RESULT_FILE,
   DEFAULT_TARGET_SIZE_SCREENSHOT_FILE,
+  HTML_SNIPPET_MAX_LENGTH,
 } from '../constants.js';
+import {
+  buildAuditResult,
+  normalizeTargetSizeCheck,
+} from '../utils/axe-format.js';
 import {
   saveAuditResult,
   takeAuditScreenshot,
@@ -48,6 +54,8 @@ import { addPageAnnotations, type AnnotationConfig } from '../utils/annotations.
 interface BasicTargetInfo {
   selector: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   role: string | null;
   width: number;
   height: number;
@@ -67,7 +75,28 @@ interface BasicTargetInfo {
 /**
  * Collect basic target information from DOM (runs in browser context).
  */
-function collectBasicTargetInfo(interactiveSelector: string): BasicTargetInfo[] {
+function collectBasicTargetInfo(args: {
+  interactiveSelector: string;
+  htmlSnippetMaxLength: number;
+}): BasicTargetInfo[] {
+  const { interactiveSelector, htmlSnippetMaxLength } = args;
+
+  function getHtmlSnippet(element: Element): { html: string; htmlTruncated: boolean } {
+    let html = '';
+    try {
+      html = element.outerHTML || '';
+    } catch {
+      html = '';
+    }
+    if (!html) {
+      return { html: `<${element.tagName.toLowerCase()}>`, htmlTruncated: false };
+    }
+    if (html.length > htmlSnippetMaxLength) {
+      return { html: html.slice(0, htmlSnippetMaxLength), htmlTruncated: true };
+    }
+    return { html, htmlTruncated: false };
+  }
+
   function getUniqueSelector(element: Element, elementIndex: number): string {
     if (element.id) {
       return `#${CSS.escape(element.id)}`;
@@ -130,6 +159,7 @@ function collectBasicTargetInfo(interactiveSelector: string): BasicTargetInfo[] 
     targets.push({
       selector: getUniqueSelector(element, index),
       tagName,
+      ...getHtmlSnippet(element),
       role,
       width: Math.round(rect.width * 100) / 100,
       height: Math.round(rect.height * 100) / 100,
@@ -369,6 +399,8 @@ function analyzeTargets(
     const issue: TargetSizeIssue = {
       selector: target.selector,
       tagName: target.tagName,
+      html: target.html,
+      htmlTruncated: target.htmlTruncated,
       role: target.role,
       accessibleName: target.accessibleName,
       width: target.width,
@@ -377,6 +409,9 @@ function analyzeTargets(
       level,
       exception,
       exceptionDetails,
+      // the heuristics can detect exceptions but can never rule out the
+      // essential exception, so findings are at best 'possible'/'not-assessed'.
+      exceptionAssessment: exception ? 'possible' : 'not-assessed',
       href: target.href,
     };
 
@@ -419,10 +454,10 @@ export async function runTargetSizeCheck(
   } = options;
 
   // Collect basic target info from DOM
-  const basicTargets = await page.evaluate(
-    collectBasicTargetInfo,
-    INTERACTIVE_SELECTOR
-  );
+  const basicTargets = await page.evaluate(collectBasicTargetInfo, {
+    interactiveSelector: INTERACTIVE_SELECTOR,
+    htmlSnippetMaxLength: HTML_SNIPPET_MAX_LENGTH,
+  });
 
   // Enhance with accessible names via ariaSnapshot()
   const targets: Array<BasicTargetInfo & { accessibleName: string | null }> = [];
@@ -450,8 +485,7 @@ export async function runTargetSizeCheck(
     aaaThreshold
   );
 
-  const result: TargetSizeCheckResult = {
-    url: page.url(),
+  const details: TargetSizeCheckDetails = {
     totalTargetsChecked: targets.length,
     failAA,
     failAAAOnly,
@@ -465,20 +499,27 @@ export async function runTargetSizeCheck(
     },
   };
 
+  const result: TargetSizeCheckResult = buildAuditResult({
+    source: 'target-size-check',
+    url: page.url(),
+    details,
+    buckets: normalizeTargetSizeCheck(details),
+  });
+
   // Output results
   logAuditHeader('Target Size Check Results', 'WCAG 2.5.5 / 2.5.8', result.url);
 
   logSummary({
-    'Total targets checked': result.totalTargetsChecked,
+    'Total targets checked': details.totalTargetsChecked,
   });
 
   console.log('\nSummary:');
-  console.log(`  Pass (>= ${aaaThreshold}px): ${result.summary.passCount}`);
+  console.log(`  Pass (>= ${aaaThreshold}px): ${details.summary.passCount}`);
   console.log(
-    `  Fail AAA only (${aaThreshold}-${aaaThreshold - 1}px): ${result.summary.failAAAOnlyCount}`
+    `  Fail AAA only (${aaThreshold}-${aaaThreshold - 1}px): ${details.summary.failAAAOnlyCount}`
   );
-  console.log(`  Fail AA (< ${aaThreshold}px): ${result.summary.failAACount}`);
-  console.log(`  Possible exceptions: ${result.summary.exceptedCount}`);
+  console.log(`  Fail AA (< ${aaThreshold}px): ${details.summary.failAACount}`);
+  console.log(`  Possible exceptions: ${details.summary.exceptedCount}`);
 
   logIssueList<TargetSizeIssue>(
     `Fail AA (< ${aaThreshold}px) - Requires Fix`,

--- a/packages/a11y-audit/src/playwright/runTextSpacingCheck.ts
+++ b/packages/a11y-audit/src/playwright/runTextSpacingCheck.ts
@@ -9,14 +9,23 @@
  */
 
 import type { Page } from '@playwright/test';
-import type { TextSpacingCheckResult, TextSpacingIssue } from '../types.js';
+import type {
+  TextSpacingCheckResult,
+  TextSpacingCheckDetails,
+  TextSpacingIssue,
+} from '../types.js';
 import {
   TEXT_SPACING_CSS,
   TEXT_SPACING_CLIP_TOLERANCE,
   TEXT_SPACING_CHECK_SELECTOR,
   DEFAULT_TEXT_SPACING_RESULT_FILE,
   DEFAULT_TEXT_SPACING_SCREENSHOT_FILE,
+  HTML_SNIPPET_MAX_LENGTH,
 } from '../constants.js';
+import {
+  buildAuditResult,
+  normalizeTextSpacingCheck,
+} from '../utils/axe-format.js';
 import {
   saveAuditResult,
   takeAuditScreenshot,
@@ -31,6 +40,8 @@ import {
 interface ElementMetrics {
   selector: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   scrollWidth: number;
   scrollHeight: number;
   clientWidth: number;
@@ -41,8 +52,27 @@ interface ElementMetrics {
 }
 
 /** Collect metrics for elements with hidden overflow (browser context). */
-function collectElementMetrics(args: { checkSelector: string }): ElementMetrics[] {
-  const { checkSelector } = args;
+function collectElementMetrics(args: {
+  checkSelector: string;
+  htmlSnippetMaxLength: number;
+}): ElementMetrics[] {
+  const { checkSelector, htmlSnippetMaxLength } = args;
+
+  function getHtmlSnippet(element: Element): { html: string; htmlTruncated: boolean } {
+    let html = '';
+    try {
+      html = element.outerHTML || '';
+    } catch {
+      html = '';
+    }
+    if (!html) {
+      return { html: `<${element.tagName.toLowerCase()}>`, htmlTruncated: false };
+    }
+    if (html.length > htmlSnippetMaxLength) {
+      return { html: html.slice(0, htmlSnippetMaxLength), htmlTruncated: true };
+    }
+    return { html, htmlTruncated: false };
+  }
 
   function getUniqueSelector(element: Element, elementIndex: number): string {
     if (element.id) {
@@ -98,6 +128,7 @@ function collectElementMetrics(args: { checkSelector: string }): ElementMetrics[
       metrics.push({
         selector: getUniqueSelector(element, index),
         tagName: element.tagName.toLowerCase(),
+        ...getHtmlSnippet(element),
         scrollWidth: element.scrollWidth,
         scrollHeight: element.scrollHeight,
         clientWidth: element.clientWidth,
@@ -116,8 +147,9 @@ function collectElementMetrics(args: { checkSelector: string }): ElementMetrics[
 function injectSpacingAndCollect(args: {
   css: string;
   checkSelector: string;
+  htmlSnippetMaxLength: number;
 }): ElementMetrics[] {
-  const { css, checkSelector } = args;
+  const { css, checkSelector, htmlSnippetMaxLength } = args;
 
   const styleEl = document.createElement('style');
   styleEl.id = 'wcag-text-spacing-override';
@@ -126,6 +158,22 @@ function injectSpacingAndCollect(args: {
 
   // Force reflow
   void document.body.offsetHeight;
+
+  function getHtmlSnippet(element: Element): { html: string; htmlTruncated: boolean } {
+    let html = '';
+    try {
+      html = element.outerHTML || '';
+    } catch {
+      html = '';
+    }
+    if (!html) {
+      return { html: `<${element.tagName.toLowerCase()}>`, htmlTruncated: false };
+    }
+    if (html.length > htmlSnippetMaxLength) {
+      return { html: html.slice(0, htmlSnippetMaxLength), htmlTruncated: true };
+    }
+    return { html, htmlTruncated: false };
+  }
 
   function getUniqueSelector(element: Element, elementIndex: number): string {
     if (element.id) {
@@ -181,6 +229,7 @@ function injectSpacingAndCollect(args: {
       metrics.push({
         selector: getUniqueSelector(element, index),
         tagName: element.tagName.toLowerCase(),
+        ...getHtmlSnippet(element),
         scrollWidth: element.scrollWidth,
         scrollHeight: element.scrollHeight,
         clientWidth: element.clientWidth,
@@ -255,6 +304,8 @@ function detectClippingIssues(
       issues.push({
         selector: after.selector,
         tagName: after.tagName,
+        html: after.html,
+        htmlTruncated: after.htmlTruncated,
         beforeMetrics: {
           scrollWidth: beforeData.scrollWidth,
           scrollHeight: beforeData.scrollHeight,
@@ -303,11 +354,13 @@ export async function runTextSpacingCheck(
 
   const beforeMetrics = await page.evaluate(collectElementMetrics, {
     checkSelector: TEXT_SPACING_CHECK_SELECTOR,
+    htmlSnippetMaxLength: HTML_SNIPPET_MAX_LENGTH,
   });
 
   const afterMetrics = await page.evaluate(injectSpacingAndCollect, {
     css: TEXT_SPACING_CSS,
     checkSelector: TEXT_SPACING_CHECK_SELECTOR,
+    htmlSnippetMaxLength: HTML_SNIPPET_MAX_LENGTH,
   });
 
   const clippedElements = detectClippingIssues(
@@ -316,22 +369,28 @@ export async function runTextSpacingCheck(
     tolerance
   );
 
-  const result: TextSpacingCheckResult = {
-    url: page.url(),
+  const details: TextSpacingCheckDetails = {
     clippedElements,
     totalElementsChecked: afterMetrics.length,
   };
 
+  const result: TextSpacingCheckResult = buildAuditResult({
+    source: 'text-spacing-check',
+    url: page.url(),
+    details,
+    buckets: normalizeTextSpacingCheck(details),
+  });
+
   logAuditHeader('Text Spacing Check Results', 'WCAG 1.4.12', result.url);
 
   logSummary({
-    'Elements with overflow:hidden checked': result.totalElementsChecked,
-    'Elements with clipping issues': result.clippedElements.length,
+    'Elements with overflow:hidden checked': details.totalElementsChecked,
+    'Elements with clipping issues': details.clippedElements.length,
   });
 
   logIssueList<TextSpacingIssue>(
     'Clipped Elements',
-    result.clippedElements,
+    details.clippedElements,
     (el, i) => [
       `${i + 1}. <${el.tagName}> "${el.selector}"`,
       `   Issue: ${el.issueType}`,

--- a/packages/a11y-audit/src/playwright/runTimeLimitDetector.ts
+++ b/packages/a11y-audit/src/playwright/runTimeLimitDetector.ts
@@ -14,6 +14,7 @@
 import type { Page } from '@playwright/test';
 import type {
   TimeLimitDetectorResult,
+  TimeLimitDetectorDetails,
   MetaRefreshInfo,
   TimerInfo,
   CountdownIndicator,
@@ -23,7 +24,12 @@ import {
   TIME_LIMIT_THRESHOLD_MS,
   TIME_LIMIT_MIN_MS,
   DEFAULT_TIME_LIMIT_RESULT_FILE,
+  HTML_SNIPPET_MAX_LENGTH,
 } from '../constants.js';
+import {
+  buildAuditResult,
+  normalizeTimeLimitDetector,
+} from '../utils/axe-format.js';
 import {
   saveAuditResult,
   requireTargetUrl,
@@ -103,8 +109,25 @@ interface TimeLimitIndicatorsResult {
 /** Detect meta refresh + countdown indicators (browser context). */
 function detectTimeLimitIndicators(args: {
   keywords: readonly string[];
+  htmlSnippetMaxLength: number;
 }): TimeLimitIndicatorsResult {
-  const { keywords } = args;
+  const { keywords, htmlSnippetMaxLength } = args;
+
+  function getHtmlSnippet(element: Element): { html: string; htmlTruncated: boolean } {
+    let html = '';
+    try {
+      html = element.outerHTML || '';
+    } catch {
+      html = '';
+    }
+    if (!html) {
+      return { html: `<${element.tagName.toLowerCase()}>`, htmlTruncated: false };
+    }
+    if (html.length > htmlSnippetMaxLength) {
+      return { html: html.slice(0, htmlSnippetMaxLength), htmlTruncated: true };
+    }
+    return { html, htmlTruncated: false };
+  }
 
   function getUniqueSelector(element: Element, elementIndex: number): string {
     if (element.id) {
@@ -138,6 +161,7 @@ function detectTimeLimitIndicators(args: {
           content,
           seconds: parseInt(match[1] ?? '0', 10),
           url: match[2]?.trim() || null,
+          ...getHtmlSnippet(meta),
         });
       }
     }
@@ -171,6 +195,7 @@ function detectTimeLimitIndicators(args: {
               selector: getUniqueSelector(parent, elementIndex),
               text: fullText,
               tagName: parent.tagName.toLowerCase(),
+              ...getHtmlSnippet(parent),
             });
           }
         }
@@ -225,6 +250,7 @@ export async function runTimeLimitDetector(
 
   const indicators = await page.evaluate(detectTimeLimitIndicators, {
     keywords: [...TIME_LIMIT_KEYWORDS],
+    htmlSnippetMaxLength: HTML_SNIPPET_MAX_LENGTH,
   });
 
   const hasTimeLimits =
@@ -232,24 +258,30 @@ export async function runTimeLimitDetector(
     timers.length > 0 ||
     indicators.countdownIndicators.length > 0;
 
-  const result: TimeLimitDetectorResult = {
-    url: page.url(),
+  const details: TimeLimitDetectorDetails = {
     metaRefresh: indicators.metaRefresh,
     timers,
     countdownIndicators: indicators.countdownIndicators,
     hasTimeLimits,
   };
 
+  const result: TimeLimitDetectorResult = buildAuditResult({
+    source: 'time-limit-detector',
+    url: page.url(),
+    details,
+    buckets: normalizeTimeLimitDetector(details),
+  });
+
   logAuditHeader('Time Limit Detection Results', 'WCAG 2.2.1', result.url);
 
   logSummary({
-    'Meta refresh tags': result.metaRefresh.length,
-    [`Timers detected (${minMs / 1000}s - ${maxMs / 1000}s)`]: result.timers.length,
-    'Countdown text indicators': result.countdownIndicators.length,
-    'Time limits detected': result.hasTimeLimits,
+    'Meta refresh tags': details.metaRefresh.length,
+    [`Timers detected (${minMs / 1000}s - ${maxMs / 1000}s)`]: details.timers.length,
+    'Countdown text indicators': details.countdownIndicators.length,
+    'Time limits detected': details.hasTimeLimits,
   });
 
-  logIssueList<MetaRefreshInfo>('Meta Refresh', result.metaRefresh, (meta, i) => {
+  logIssueList<MetaRefreshInfo>('Meta Refresh', details.metaRefresh, (meta, i) => {
     const lines = [
       `${i + 1}. content="${meta.content}"`,
       `   Refresh in ${meta.seconds} seconds`,
@@ -260,7 +292,7 @@ export async function runTimeLimitDetector(
     return lines;
   });
 
-  logIssueList<TimerInfo>('Detected Timers', result.timers, (timer, i) => {
+  logIssueList<TimerInfo>('Detected Timers', details.timers, (timer, i) => {
     const lines = [
       `${i + 1}. ${timer.type} - ${timer.delayMs}ms (${(timer.delayMs / 1000).toFixed(1)}s)`,
     ];
@@ -272,7 +304,7 @@ export async function runTimeLimitDetector(
 
   logIssueList<CountdownIndicator>(
     'Countdown Indicators',
-    result.countdownIndicators,
+    details.countdownIndicators,
     (indicator, i) => {
       const truncatedText =
         indicator.text.length > 80

--- a/packages/a11y-audit/src/playwright/runZoomCheck.ts
+++ b/packages/a11y-audit/src/playwright/runZoomCheck.ts
@@ -17,7 +17,7 @@
  */
 
 import type { Page } from '@playwright/test';
-import type { ZoomCheckResult, ZoomIssue } from '../types.js';
+import type { ZoomCheckResult, ZoomCheckDetails, ZoomIssue } from '../types.js';
 import {
   ZOOM_FACTOR,
   ZOOM_BASE_VIEWPORT,
@@ -25,7 +25,9 @@ import {
   REFLOW_CHECK_SELECTOR,
   DEFAULT_ZOOM_RESULT_FILE,
   DEFAULT_ZOOM_SCREENSHOT_FILE,
+  HTML_SNIPPET_MAX_LENGTH,
 } from '../constants.js';
+import { buildAuditResult, normalizeZoomCheck } from '../utils/axe-format.js';
 import {
   saveAuditResult,
   takeAuditScreenshot,
@@ -40,6 +42,7 @@ import {
 interface ZoomCheckArgs {
   checkSelector: string;
   tolerance: number;
+  htmlSnippetMaxLength: number;
 }
 
 interface ZoomCheckResponse {
@@ -51,7 +54,23 @@ interface ZoomCheckResponse {
 
 /** Apply zoom and detect issues in browser context. */
 function applyZoomAndCheck(args: ZoomCheckArgs): ZoomCheckResponse {
-  const { checkSelector, tolerance } = args;
+  const { checkSelector, tolerance, htmlSnippetMaxLength } = args;
+
+  function getHtmlSnippet(element: Element): { html: string; htmlTruncated: boolean } {
+    let html = '';
+    try {
+      html = element.outerHTML || '';
+    } catch {
+      html = '';
+    }
+    if (!html) {
+      return { html: `<${element.tagName.toLowerCase()}>`, htmlTruncated: false };
+    }
+    if (html.length > htmlSnippetMaxLength) {
+      return { html: html.slice(0, htmlSnippetMaxLength), htmlTruncated: true };
+    }
+    return { html, htmlTruncated: false };
+  }
 
   // Apply CSS zoom
   (document.documentElement.style as CSSStyleDeclaration & { zoom: string }).zoom =
@@ -133,6 +152,7 @@ function applyZoomAndCheck(args: ZoomCheckArgs): ZoomCheckResponse {
       clippedElements.push({
         selector: getUniqueSelector(element, index),
         tagName: element.tagName.toLowerCase(),
+        ...getHtmlSnippet(element),
         scrollWidth,
         clientWidth,
         scrollHeight,
@@ -191,30 +211,37 @@ export async function runZoomCheck(
   const zoomResult = await page.evaluate(applyZoomAndCheck, {
     checkSelector: REFLOW_CHECK_SELECTOR,
     tolerance: ZOOM_CLIP_TOLERANCE,
+    htmlSnippetMaxLength: HTML_SNIPPET_MAX_LENGTH,
   });
 
-  const result: ZoomCheckResult = {
-    url: page.url(),
+  const details: ZoomCheckDetails = {
     zoomFactor: ZOOM_FACTOR,
     viewport: { width: viewport.width, height: viewport.height },
     ...zoomResult,
   };
 
+  const result: ZoomCheckResult = buildAuditResult({
+    source: 'zoom-200-check',
+    url: page.url(),
+    details,
+    buckets: normalizeZoomCheck(details),
+  });
+
   // Output results
   logAuditHeader('Zoom 200% Check Results', 'WCAG 1.4.4', result.url);
 
   logSummary({
-    'Zoom factor': `${result.zoomFactor}x`,
-    'Base viewport': `${result.viewport.width}x${result.viewport.height}`,
-    'Document scroll width': `${result.documentScrollWidth}px`,
-    'Document client width': `${result.documentClientWidth}px`,
-    'Horizontal scroll': result.hasHorizontalScroll,
-    'Clipped elements': result.clippedElements.length,
+    'Zoom factor': `${details.zoomFactor}x`,
+    'Base viewport': `${details.viewport.width}x${details.viewport.height}`,
+    'Document scroll width': `${details.documentScrollWidth}px`,
+    'Document client width': `${details.documentClientWidth}px`,
+    'Horizontal scroll': details.hasHorizontalScroll,
+    'Clipped elements': details.clippedElements.length,
   });
 
   logIssueList<ZoomIssue>(
     'Clipped Elements',
-    result.clippedElements,
+    details.clippedElements,
     (el, i) => [
       `${i + 1}. <${el.tagName}> "${el.selector}"`,
       `   scrollWidth: ${el.scrollWidth}px, clientWidth: ${el.clientWidth}px`,

--- a/packages/a11y-audit/src/schemas/index.ts
+++ b/packages/a11y-audit/src/schemas/index.ts
@@ -6,36 +6,55 @@
  * (e.g. an issue creator that reads `*-result.json`). They are intentionally
  * permissive (no `additionalProperties: false`) so that additive changes to a
  * result shape do not break downstream validation.
+ *
+ * Every check shares the same envelope (`source` / `url` / `timestamp` / the
+ * four normalized buckets / `summary` / `details` / `disclaimer`); the common
+ * pieces live in `$defs` and each check schema defines its own `details`.
  */
 
 export type {
-  AxeViolationNode,
-  AxeViolation,
+  AuditCheckResult,
+  AuditResultSummary,
+  CheckSource,
+  NormalizedImpact,
+  NormalizedNode,
+  NormalizedRuleResult,
+  AxeAuditDetails,
   AxeAuditResult,
   FocusRecord,
+  FocusElementRef,
   OnFocusViolation,
+  FocusCheckDetails,
   FocusCheckResult,
   BoundingRect,
   FocusObscuredOverlap,
   FocusObscuredIssue,
   ReflowIssue,
   ClippedTextElement,
+  ReflowCheckDetails,
   ReflowCheckResult,
   TargetSizeException,
+  TargetSizeExceptionAssessment,
   TargetSizeIssue,
   TargetSizeSummary,
+  TargetSizeCheckDetails,
   TargetSizeCheckResult,
   TextSpacingIssue,
+  TextSpacingCheckDetails,
   TextSpacingCheckResult,
   ZoomIssue,
+  ZoomCheckDetails,
   ZoomCheckResult,
   OrientationState,
+  OrientationCheckDetails,
   OrientationCheckResult,
   AutocompleteIssue,
+  AutocompleteAuditDetails,
   AutocompleteAuditResult,
   MetaRefreshInfo,
   TimerInfo,
   CountdownIndicator,
+  TimeLimitDetectorDetails,
   TimeLimitDetectorResult,
   ScreenshotRecord,
   ComparisonResult,
@@ -44,6 +63,7 @@ export type {
   CarouselIndicator,
   PauseControlInfo,
   PauseVerificationResult,
+  AutoPlayDetectionDetails,
   AutoPlayDetectionResult,
 } from '../types.js';
 
@@ -51,15 +71,61 @@ export type {
 export interface JsonSchema {
   $schema?: string;
   $id?: string;
+  $ref?: string;
+  $defs?: Record<string, JsonSchema>;
   title?: string;
   type?: string | string[];
   properties?: Record<string, JsonSchema>;
   items?: JsonSchema;
   required?: string[];
   enum?: unknown[];
+  const?: unknown;
   description?: string;
   [key: string]: unknown;
 }
+
+// =============================================================================
+// Shared $defs
+// =============================================================================
+
+const NORMALIZED_NODE_SCHEMA: JsonSchema = {
+  type: 'object',
+  required: ['target', 'html', 'htmlTruncated', 'failureSummary'],
+  properties: {
+    target: { type: 'array', items: { type: 'string' } },
+    html: { type: 'string' },
+    htmlTruncated: { type: 'boolean' },
+    failureSummary: { type: 'string' },
+  },
+};
+
+const NORMALIZED_RULE_RESULT_SCHEMA: JsonSchema = {
+  type: 'object',
+  required: ['id', 'impact', 'description', 'help', 'helpUrl', 'tags', 'nodes'],
+  properties: {
+    id: { type: 'string' },
+    impact: {
+      type: ['string', 'null'],
+      enum: ['critical', 'serious', 'moderate', 'minor', null],
+    },
+    description: { type: 'string' },
+    help: { type: 'string' },
+    helpUrl: { type: 'string' },
+    tags: { type: 'array', items: { type: 'string' } },
+    nodes: { type: 'array', items: { $ref: '#/$defs/normalizedNode' } },
+  },
+};
+
+const SUMMARY_SCHEMA: JsonSchema = {
+  type: 'object',
+  required: ['violationCount', 'incompleteCount', 'passCount'],
+  properties: {
+    violationCount: { type: 'number' },
+    incompleteCount: { type: 'number' },
+    passCount: { type: 'number' },
+    checkedNodes: { type: 'number' },
+  },
+};
 
 const DISCLAIMER_SCHEMA: JsonSchema = {
   type: 'object',
@@ -71,352 +137,416 @@ const DISCLAIMER_SCHEMA: JsonSchema = {
   },
 };
 
-export const AXE_AUDIT_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/axe-audit-result.json',
-  title: 'AxeAuditResult',
-  type: 'object',
-  required: [
-    'url',
-    'timestamp',
-    'violations',
-    'passes',
-    'incomplete',
-    'inapplicable',
-    'violationCount',
-  ],
-  properties: {
-    url: { type: 'string' },
-    timestamp: { type: 'string' },
-    violations: {
-      type: 'array',
-      items: {
-        type: 'object',
-        required: ['id', 'description', 'help', 'helpUrl', 'tags', 'nodes'],
-        properties: {
-          id: { type: 'string' },
-          impact: { type: ['string', 'null'] },
-          description: { type: 'string' },
-          help: { type: 'string' },
-          helpUrl: { type: 'string' },
-          tags: { type: 'array', items: { type: 'string' } },
-          nodes: {
-            type: 'array',
-            items: {
-              type: 'object',
-              required: ['html', 'target'],
-              properties: {
-                html: { type: 'string' },
-                target: { type: 'array', items: { type: 'string' } },
-                failureSummary: { type: ['string', 'null'] },
-              },
-            },
-          },
-        },
-      },
+const COMMON_DEFS: Record<string, JsonSchema> = {
+  normalizedNode: NORMALIZED_NODE_SCHEMA,
+  normalizedRuleResult: NORMALIZED_RULE_RESULT_SCHEMA,
+  summary: SUMMARY_SCHEMA,
+  disclaimer: DISCLAIMER_SCHEMA,
+};
+
+const RULE_ARRAY: JsonSchema = {
+  type: 'array',
+  items: { $ref: '#/$defs/normalizedRuleResult' },
+};
+
+/** Build the envelope schema for one check, plugging in its details schema. */
+function buildEnvelopeSchema(args: {
+  id: string;
+  title: string;
+  source: string;
+  details: JsonSchema;
+}): JsonSchema {
+  return {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    $id: `https://masup9.github.io/a11y-audit/schemas/${args.id}.json`,
+    title: args.title,
+    type: 'object',
+    required: [
+      'source',
+      'url',
+      'timestamp',
+      'violations',
+      'incomplete',
+      'passes',
+      'inapplicable',
+      'summary',
+      'details',
+      'disclaimer',
+    ],
+    properties: {
+      source: { const: args.source },
+      url: { type: 'string' },
+      timestamp: { type: 'string' },
+      violations: RULE_ARRAY,
+      incomplete: RULE_ARRAY,
+      passes: RULE_ARRAY,
+      inapplicable: RULE_ARRAY,
+      summary: { $ref: '#/$defs/summary' },
+      details: args.details,
+      disclaimer: { $ref: '#/$defs/disclaimer' },
     },
-    passes: { type: 'number' },
-    incomplete: { type: 'number' },
-    inapplicable: { type: 'number' },
-    violationCount: { type: 'number' },
-    disclaimer: DISCLAIMER_SCHEMA,
-  },
+    $defs: COMMON_DEFS,
+  };
+}
+
+// =============================================================================
+// Detail building blocks
+// =============================================================================
+
+const ELEMENT_EVIDENCE_PROPS: Record<string, JsonSchema> = {
+  selector: { type: 'string' },
+  tagName: { type: 'string' },
+  html: { type: 'string' },
+  htmlTruncated: { type: 'boolean' },
 };
 
 const FOCUS_ELEMENT_REF_SCHEMA: JsonSchema = {
   type: 'object',
-  required: ['tag', 'name', 'selector'],
+  required: ['tag', 'name', 'selector', 'html', 'htmlTruncated'],
   properties: {
     tag: { type: 'string' },
     role: { type: ['string', 'null'] },
     name: { type: 'string' },
     selector: { type: 'string' },
+    html: { type: 'string' },
+    htmlTruncated: { type: 'boolean' },
   },
 };
 
-export const FOCUS_CHECK_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/focus-check-result.json',
+// =============================================================================
+// Check schemas
+// =============================================================================
+
+export const AXE_AUDIT_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'axe-audit-result',
+  title: 'AxeAuditResult',
+  source: 'axe-audit',
+  details: {
+    type: 'object',
+    required: [
+      'tagsRun',
+      'rulesOverride',
+      'violationRuleCount',
+      'passRuleCount',
+      'incompleteRuleCount',
+      'inapplicableRuleCount',
+    ],
+    properties: {
+      tagsRun: { type: 'array', items: { type: 'string' } },
+      rulesOverride: { type: ['object', 'null'] },
+      violationRuleCount: { type: 'number' },
+      passRuleCount: { type: 'number' },
+      incompleteRuleCount: { type: 'number' },
+      inapplicableRuleCount: { type: 'number' },
+    },
+  },
+});
+
+export const FOCUS_CHECK_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'focus-check-result',
   title: 'FocusCheckResult',
-  type: 'object',
-  required: [
-    'url',
-    'totalFocusableElements',
-    'elementsWithFocusStyle',
-    'elementsWithoutFocusStyle',
-    'issues',
-    'onFocusViolations',
-    'focusObscuredIssues',
-    'elementsWithObscuredFocus',
-    'allElements',
-    'interrupted',
-    'screenshotPath',
-  ],
-  properties: {
-    url: { type: 'string' },
-    totalFocusableElements: { type: 'number' },
-    elementsWithFocusStyle: { type: 'number' },
-    elementsWithoutFocusStyle: { type: 'number' },
-    issues: {
-      type: 'array',
-      items: {
-        type: 'object',
-        required: ['tag', 'name'],
-        properties: {
-          tag: { type: 'string' },
-          role: { type: ['string', 'null'] },
-          name: { type: 'string' },
-        },
-      },
-    },
-    onFocusViolations: {
-      type: 'array',
-      items: {
-        type: 'object',
-        required: ['element', 'fromUrl', 'toUrl', 'changeType'],
-        properties: {
-          element: FOCUS_ELEMENT_REF_SCHEMA,
-          fromUrl: { type: 'string' },
-          toUrl: { type: 'string' },
-          changeType: {
-            type: 'string',
-            enum: ['navigation', 'new-window', 'dialog'],
+  source: 'focus-indicator-check',
+  details: {
+    type: 'object',
+    required: [
+      'totalFocusableElements',
+      'elementsWithFocusStyle',
+      'elementsWithoutFocusStyle',
+      'issues',
+      'onFocusViolations',
+      'focusObscuredIssues',
+      'elementsWithObscuredFocus',
+      'allElements',
+      'interrupted',
+      'screenshotPath',
+    ],
+    properties: {
+      totalFocusableElements: { type: 'number' },
+      elementsWithFocusStyle: { type: 'number' },
+      elementsWithoutFocusStyle: { type: 'number' },
+      issues: { type: 'array', items: FOCUS_ELEMENT_REF_SCHEMA },
+      onFocusViolations: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['element', 'fromUrl', 'toUrl', 'changeType'],
+          properties: {
+            element: FOCUS_ELEMENT_REF_SCHEMA,
+            fromUrl: { type: 'string' },
+            toUrl: { type: 'string' },
+            changeType: {
+              type: 'string',
+              enum: ['navigation', 'new-window', 'dialog'],
+            },
           },
         },
       },
-    },
-    focusObscuredIssues: {
-      type: 'array',
-      items: {
-        type: 'object',
-        required: ['element', 'elementRect', 'overlaps', 'obscuredRatio'],
-        properties: {
-          element: FOCUS_ELEMENT_REF_SCHEMA,
-          elementRect: { type: 'object' },
-          overlaps: { type: 'array', items: { type: 'object' } },
-          obscuredRatio: { type: 'number' },
+      focusObscuredIssues: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['element', 'elementRect', 'overlaps', 'obscuredRatio'],
+          properties: {
+            element: FOCUS_ELEMENT_REF_SCHEMA,
+            elementRect: { type: 'object' },
+            overlaps: { type: 'array', items: { type: 'object' } },
+            obscuredRatio: { type: 'number' },
+          },
         },
       },
+      elementsWithObscuredFocus: { type: 'number' },
+      allElements: { type: 'array', items: { type: 'object' } },
+      interrupted: { type: 'boolean' },
+      interruptedAt: { type: 'number' },
+      screenshotPath: { type: 'string' },
     },
-    elementsWithObscuredFocus: { type: 'number' },
-    allElements: { type: 'array', items: { type: 'object' } },
-    interrupted: { type: 'boolean' },
-    interruptedAt: { type: 'number' },
-    screenshotPath: { type: 'string' },
-    disclaimer: DISCLAIMER_SCHEMA,
   },
-};
+});
 
-export const REFLOW_CHECK_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/reflow-check-result.json',
+export const REFLOW_CHECK_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'reflow-check-result',
   title: 'ReflowCheckResult',
-  type: 'object',
-  required: [
-    'url',
-    'viewport',
-    'hasHorizontalScroll',
-    'documentScrollWidth',
-    'documentClientWidth',
-    'overflowingElements',
-    'clippedTextElements',
-  ],
-  properties: {
-    url: { type: 'string' },
-    viewport: {
-      type: 'object',
-      required: ['width', 'height'],
-      properties: {
-        width: { type: 'number' },
-        height: { type: 'number' },
-      },
-    },
-    hasHorizontalScroll: { type: 'boolean' },
-    documentScrollWidth: { type: 'number' },
-    documentClientWidth: { type: 'number' },
-    overflowingElements: {
-      type: 'array',
-      items: {
+  source: 'reflow-check',
+  details: {
+    type: 'object',
+    required: [
+      'viewport',
+      'hasHorizontalScroll',
+      'documentScrollWidth',
+      'documentClientWidth',
+      'overflowingElements',
+      'clippedTextElements',
+    ],
+    properties: {
+      viewport: {
         type: 'object',
-        required: ['selector', 'tagName', 'rect', 'viewportWidth', 'reason'],
+        required: ['width', 'height'],
         properties: {
-          selector: { type: 'string' },
-          tagName: { type: 'string' },
-          rect: { type: 'object' },
-          viewportWidth: { type: 'number' },
-          reason: {
-            type: 'string',
-            enum: ['overflow-right', 'overflow-left', 'clipped-text'],
+          width: { type: 'number' },
+          height: { type: 'number' },
+        },
+      },
+      hasHorizontalScroll: { type: 'boolean' },
+      documentScrollWidth: { type: 'number' },
+      documentClientWidth: { type: 'number' },
+      overflowingElements: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: [
+            'selector',
+            'tagName',
+            'html',
+            'htmlTruncated',
+            'rect',
+            'viewportWidth',
+            'reason',
+          ],
+          properties: {
+            ...ELEMENT_EVIDENCE_PROPS,
+            rect: { type: 'object' },
+            viewportWidth: { type: 'number' },
+            reason: {
+              type: 'string',
+              enum: ['overflow-right', 'overflow-left', 'clipped-text'],
+            },
           },
         },
       },
+      clippedTextElements: { type: 'array', items: { type: 'object' } },
     },
-    clippedTextElements: { type: 'array', items: { type: 'object' } },
-    disclaimer: DISCLAIMER_SCHEMA,
   },
-};
+});
 
-export const TARGET_SIZE_CHECK_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/target-size-check-result.json',
+export const TARGET_SIZE_CHECK_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'target-size-check-result',
   title: 'TargetSizeCheckResult',
-  type: 'object',
-  required: [
-    'url',
-    'totalTargetsChecked',
-    'failAA',
-    'failAAAOnly',
-    'passedTargets',
-    'exceptedTargets',
-    'summary',
-  ],
-  properties: {
-    url: { type: 'string' },
-    totalTargetsChecked: { type: 'number' },
-    failAA: { type: 'array', items: { type: 'object' } },
-    failAAAOnly: { type: 'array', items: { type: 'object' } },
-    passedTargets: { type: 'number' },
-    exceptedTargets: { type: 'array', items: { type: 'object' } },
-    summary: {
-      type: 'object',
-      required: [
-        'failAACount',
-        'failAAAOnlyCount',
-        'passCount',
-        'exceptedCount',
-      ],
-      properties: {
-        failAACount: { type: 'number' },
-        failAAAOnlyCount: { type: 'number' },
-        passCount: { type: 'number' },
-        exceptedCount: { type: 'number' },
+  source: 'target-size-check',
+  details: {
+    type: 'object',
+    required: [
+      'totalTargetsChecked',
+      'failAA',
+      'failAAAOnly',
+      'passedTargets',
+      'exceptedTargets',
+      'summary',
+    ],
+    properties: {
+      totalTargetsChecked: { type: 'number' },
+      failAA: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: [
+            'selector',
+            'tagName',
+            'html',
+            'htmlTruncated',
+            'width',
+            'height',
+            'minDimension',
+            'level',
+            'exceptionAssessment',
+          ],
+          properties: {
+            ...ELEMENT_EVIDENCE_PROPS,
+            role: { type: ['string', 'null'] },
+            accessibleName: { type: ['string', 'null'] },
+            width: { type: 'number' },
+            height: { type: 'number' },
+            minDimension: { type: 'number' },
+            level: {
+              type: 'string',
+              enum: ['fail-aa', 'fail-aaa-only', 'pass'],
+            },
+            exception: { type: ['string', 'null'] },
+            exceptionDetails: { type: ['string', 'null'] },
+            exceptionAssessment: {
+              type: 'string',
+              enum: ['ruled-out', 'possible', 'not-assessed'],
+            },
+            href: { type: ['string', 'null'] },
+          },
+        },
+      },
+      failAAAOnly: { type: 'array', items: { type: 'object' } },
+      passedTargets: { type: 'number' },
+      exceptedTargets: { type: 'array', items: { type: 'object' } },
+      summary: {
+        type: 'object',
+        required: [
+          'failAACount',
+          'failAAAOnlyCount',
+          'passCount',
+          'exceptedCount',
+        ],
+        properties: {
+          failAACount: { type: 'number' },
+          failAAAOnlyCount: { type: 'number' },
+          passCount: { type: 'number' },
+          exceptedCount: { type: 'number' },
+        },
       },
     },
-    disclaimer: DISCLAIMER_SCHEMA,
   },
-};
+});
 
-export const TEXT_SPACING_CHECK_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/text-spacing-check-result.json',
+export const TEXT_SPACING_CHECK_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'text-spacing-check-result',
   title: 'TextSpacingCheckResult',
-  type: 'object',
-  required: ['url', 'clippedElements', 'totalElementsChecked'],
-  properties: {
-    url: { type: 'string' },
-    clippedElements: { type: 'array', items: { type: 'object' } },
-    totalElementsChecked: { type: 'number' },
-    disclaimer: DISCLAIMER_SCHEMA,
-  },
-};
-
-export const ZOOM_CHECK_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/zoom-check-result.json',
-  title: 'ZoomCheckResult',
-  type: 'object',
-  required: [
-    'url',
-    'zoomFactor',
-    'viewport',
-    'hasHorizontalScroll',
-    'documentScrollWidth',
-    'documentClientWidth',
-    'clippedElements',
-  ],
-  properties: {
-    url: { type: 'string' },
-    zoomFactor: { type: 'number' },
-    viewport: { type: 'object' },
-    hasHorizontalScroll: { type: 'boolean' },
-    documentScrollWidth: { type: 'number' },
-    documentClientWidth: { type: 'number' },
-    clippedElements: { type: 'array', items: { type: 'object' } },
-    disclaimer: DISCLAIMER_SCHEMA,
-  },
-};
-
-export const ORIENTATION_CHECK_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/orientation-check-result.json',
-  title: 'OrientationCheckResult',
-  type: 'object',
-  required: ['url', 'portrait', 'landscape', 'hasOrientationLock', 'lockDetectedIn'],
-  properties: {
-    url: { type: 'string' },
-    portrait: { type: 'object' },
-    landscape: { type: 'object' },
-    hasOrientationLock: { type: 'boolean' },
-    lockDetectedIn: {
-      type: 'string',
-      enum: ['portrait', 'landscape', 'both', 'none'],
+  source: 'text-spacing-check',
+  details: {
+    type: 'object',
+    required: ['clippedElements', 'totalElementsChecked'],
+    properties: {
+      clippedElements: { type: 'array', items: { type: 'object' } },
+      totalElementsChecked: { type: 'number' },
     },
-    disclaimer: DISCLAIMER_SCHEMA,
   },
-};
+});
 
-export const AUTOCOMPLETE_AUDIT_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/autocomplete-audit-result.json',
+export const ZOOM_CHECK_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'zoom-check-result',
+  title: 'ZoomCheckResult',
+  source: 'zoom-200-check',
+  details: {
+    type: 'object',
+    required: [
+      'zoomFactor',
+      'viewport',
+      'hasHorizontalScroll',
+      'documentScrollWidth',
+      'documentClientWidth',
+      'clippedElements',
+    ],
+    properties: {
+      zoomFactor: { type: 'number' },
+      viewport: { type: 'object' },
+      hasHorizontalScroll: { type: 'boolean' },
+      documentScrollWidth: { type: 'number' },
+      documentClientWidth: { type: 'number' },
+      clippedElements: { type: 'array', items: { type: 'object' } },
+    },
+  },
+});
+
+export const ORIENTATION_CHECK_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'orientation-check-result',
+  title: 'OrientationCheckResult',
+  source: 'orientation-check',
+  details: {
+    type: 'object',
+    required: ['portrait', 'landscape', 'hasOrientationLock', 'lockDetectedIn'],
+    properties: {
+      portrait: { type: 'object' },
+      landscape: { type: 'object' },
+      hasOrientationLock: { type: 'boolean' },
+      lockDetectedIn: {
+        type: 'string',
+        enum: ['portrait', 'landscape', 'both', 'none'],
+      },
+    },
+  },
+});
+
+export const AUTOCOMPLETE_AUDIT_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'autocomplete-audit-result',
   title: 'AutocompleteAuditResult',
-  type: 'object',
-  required: [
-    'url',
-    'totalFieldsChecked',
-    'missingAutocomplete',
-    'invalidAutocomplete',
-  ],
-  properties: {
-    url: { type: 'string' },
-    totalFieldsChecked: { type: 'number' },
-    missingAutocomplete: { type: 'array', items: { type: 'object' } },
-    invalidAutocomplete: { type: 'array', items: { type: 'object' } },
-    disclaimer: DISCLAIMER_SCHEMA,
+  source: 'autocomplete-audit',
+  details: {
+    type: 'object',
+    required: ['totalFieldsChecked', 'missingAutocomplete', 'invalidAutocomplete'],
+    properties: {
+      totalFieldsChecked: { type: 'number' },
+      missingAutocomplete: { type: 'array', items: { type: 'object' } },
+      invalidAutocomplete: { type: 'array', items: { type: 'object' } },
+    },
   },
-};
+});
 
-export const TIME_LIMIT_DETECTOR_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/time-limit-detector-result.json',
+export const TIME_LIMIT_DETECTOR_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'time-limit-detector-result',
   title: 'TimeLimitDetectorResult',
-  type: 'object',
-  required: ['url', 'metaRefresh', 'timers', 'countdownIndicators', 'hasTimeLimits'],
-  properties: {
-    url: { type: 'string' },
-    metaRefresh: { type: 'array', items: { type: 'object' } },
-    timers: { type: 'array', items: { type: 'object' } },
-    countdownIndicators: { type: 'array', items: { type: 'object' } },
-    hasTimeLimits: { type: 'boolean' },
-    disclaimer: DISCLAIMER_SCHEMA,
+  source: 'time-limit-detector',
+  details: {
+    type: 'object',
+    required: ['metaRefresh', 'timers', 'countdownIndicators', 'hasTimeLimits'],
+    properties: {
+      metaRefresh: { type: 'array', items: { type: 'object' } },
+      timers: { type: 'array', items: { type: 'object' } },
+      countdownIndicators: { type: 'array', items: { type: 'object' } },
+      hasTimeLimits: { type: 'boolean' },
+    },
   },
-};
+});
 
-export const AUTO_PLAY_DETECTION_RESULT_SCHEMA: JsonSchema = {
-  $schema: 'https://json-schema.org/draft/2020-12/schema',
-  $id: 'https://masup9.github.io/a11y-audit/schemas/auto-play-detection-result.json',
+export const AUTO_PLAY_DETECTION_RESULT_SCHEMA: JsonSchema = buildEnvelopeSchema({
+  id: 'auto-play-detection-result',
   title: 'AutoPlayDetectionResult',
-  type: 'object',
-  required: [
-    'url',
-    'screenshotRecords',
-    'comparisons',
-    'hasAutoPlayContent',
-    'stopsWithin5Seconds',
-    'pauseControls',
-    'pauseVerification',
-    'recommendation',
-  ],
-  properties: {
-    url: { type: 'string' },
-    screenshotRecords: { type: 'array', items: { type: 'object' } },
-    comparisons: { type: 'array', items: { type: 'object' } },
-    hasAutoPlayContent: { type: 'boolean' },
-    stopsWithin5Seconds: { type: 'boolean' },
-    pauseControls: { type: 'object' },
-    pauseVerification: { type: 'object' },
-    recommendation: { type: 'string' },
+  source: 'auto-play-detection',
+  details: {
+    type: 'object',
+    required: [
+      'screenshotRecords',
+      'comparisons',
+      'hasAutoPlayContent',
+      'stopsWithin5Seconds',
+      'pauseControls',
+      'pauseVerification',
+      'recommendation',
+    ],
+    properties: {
+      screenshotRecords: { type: 'array', items: { type: 'object' } },
+      comparisons: { type: 'array', items: { type: 'object' } },
+      hasAutoPlayContent: { type: 'boolean' },
+      stopsWithin5Seconds: { type: 'boolean' },
+      pauseControls: { type: 'object' },
+      pauseVerification: { type: 'object' },
+      recommendation: { type: 'string' },
+    },
   },
-};
+});
 
 /** All result schemas keyed by check id. */
 export const RESULT_SCHEMAS = {

--- a/packages/a11y-audit/src/types.ts
+++ b/packages/a11y-audit/src/types.ts
@@ -1,42 +1,119 @@
 /**
  * Type definitions for the WCAG audit checks shipped in @a11y-skills/audit.
+ *
+ * Every check returns the same axe-style envelope (`AuditCheckResult`):
+ * findings are normalized into `violations` / `incomplete` / `passes` /
+ * `inapplicable` rule arrays, while the check-specific evidence (measurements,
+ * screenshots, raw element records) lives under `details`.
+ *
+ * Classification policy: a finding is only a `violation` when the detection
+ * has no known blind spots and no WCAG exception could apply. Everything else
+ * (most heuristic detections) lands in `incomplete` — the manual-review queue.
  */
 
 import type { AUDIT_DISCLAIMER } from './constants.js';
 
 // =============================================================================
-// Axe Audit Types (broad WCAG coverage)
+// Normalized envelope (axe-style common format)
 // =============================================================================
 
-export interface AxeViolationNode {
-  html: string;
+/** Identifier of the check that produced a result. */
+export type CheckSource =
+  | 'axe-audit'
+  | 'focus-indicator-check'
+  | 'reflow-check'
+  | 'target-size-check'
+  | 'text-spacing-check'
+  | 'zoom-200-check'
+  | 'orientation-check'
+  | 'autocomplete-audit'
+  | 'time-limit-detector'
+  | 'auto-play-detection';
+
+export type NormalizedImpact = 'critical' | 'serious' | 'moderate' | 'minor';
+
+/** One affected element (or the page itself, `target: ['html']`). */
+export interface NormalizedNode {
+  /** CSS selector path. Page-level findings use `['html']`. */
   target: string[];
-  failureSummary: string | undefined;
+  /**
+   * outerHTML snippet (possibly truncated). When the source element's HTML
+   * could not be captured, a short synthetic representation is generated from
+   * the tag/role/name instead — never an empty string.
+   */
+  html: string;
+  /** Whether `html` was truncated to the snippet length limit. */
+  htmlTruncated: boolean;
+  /** Human-readable description of why this node was flagged. */
+  failureSummary: string;
 }
 
-export interface AxeViolation {
+/** One rule's outcome, axe-style. */
+export interface NormalizedRuleResult {
+  /** Namespaced rule id, e.g. `a11y-skills/focus-visible` (axe rules keep their own ids). */
   id: string;
-  impact: string | null;
+  impact: NormalizedImpact | null;
   description: string;
   help: string;
+  /** W3C Understanding document (or axe docs for axe rules). */
   helpUrl: string;
+  /** axe-style tags: `a11y-skills`, `wcag2aa` / `wcag21aa` / `wcag22aa`, `wcag247`-style SC tags. */
   tags: string[];
-  nodes: AxeViolationNode[];
+  nodes: NormalizedNode[];
 }
 
-export interface AxeAuditResult {
+/** Rule-level counts derived from the four buckets (not from `details`). */
+export interface AuditResultSummary {
+  /** Number of rules in `violations`. */
+  violationCount: number;
+  /** Number of rules in `incomplete`. */
+  incompleteCount: number;
+  /** Number of rules in `passes`. */
+  passCount: number;
+  /** Number of elements the check examined, when the check can count them. */
+  checkedNodes?: number;
+}
+
+/** Common envelope returned (and saved as JSON) by every check. */
+export interface AuditCheckResult<TDetails> {
+  source: CheckSource;
   url: string;
   timestamp: string;
-  violations: AxeViolation[];
-  passes: number;
-  incomplete: number;
-  inapplicable: number;
-  violationCount: number;
+  /** Confirmed findings — detection has no blind spot and no exception can apply. */
+  violations: NormalizedRuleResult[];
+  /** Findings that need manual confirmation (heuristic detections, possible exceptions). */
+  incomplete: NormalizedRuleResult[];
+  /** Rules that ran and found nothing (nodes omitted). */
+  passes: NormalizedRuleResult[];
+  /** Rules that had nothing to examine on this page. */
+  inapplicable: NormalizedRuleResult[];
+  summary: AuditResultSummary;
+  /** Check-specific evidence; sufficient to re-derive the buckets above. */
+  details: TDetails;
   disclaimer: typeof AUDIT_DISCLAIMER;
 }
 
 // =============================================================================
-// Focus Indicator Types (WCAG 2.4.7)
+// Axe Audit (broad WCAG coverage)
+// =============================================================================
+
+/** Execution configuration; rule/node data is fully held in the envelope buckets. */
+export interface AxeAuditDetails {
+  /** axe-core tags the run was filtered by. */
+  tagsRun: string[];
+  /** Rule overrides forwarded to axe, if any. */
+  rulesOverride: Record<string, { enabled: boolean }> | null;
+  /** Raw axe result counts (rule-level). */
+  violationRuleCount: number;
+  passRuleCount: number;
+  incompleteRuleCount: number;
+  inapplicableRuleCount: number;
+}
+
+export type AxeAuditResult = AuditCheckResult<AxeAuditDetails>;
+
+// =============================================================================
+// Focus Indicator (WCAG 2.4.7 / 2.4.11 / 3.2.1)
 // =============================================================================
 
 export interface FocusRecord {
@@ -44,8 +121,21 @@ export interface FocusRecord {
   tag: string;
   role: string | null;
   name: string;
+  selector: string;
+  html: string;
+  htmlTruncated: boolean;
   hasFocusStyle: boolean;
   diff: Record<string, string>;
+}
+
+/** Reference to an element captured in the browser context. */
+export interface FocusElementRef {
+  tag: string;
+  role: string | null;
+  name: string;
+  selector: string;
+  html: string;
+  htmlTruncated: boolean;
 }
 
 /**
@@ -53,12 +143,7 @@ export interface FocusRecord {
  */
 export interface OnFocusViolation {
   /** Element that triggered the navigation */
-  element: {
-    tag: string;
-    role: string | null;
-    name: string;
-    selector: string;
-  };
+  element: FocusElementRef;
   /** URL before focus */
   fromUrl: string;
   /** URL after focus (navigation target) */
@@ -67,20 +152,15 @@ export interface OnFocusViolation {
   changeType: 'navigation' | 'new-window' | 'dialog';
 }
 
-export interface FocusCheckResult {
-  url: string;
+export interface FocusCheckDetails {
   totalFocusableElements: number;
   elementsWithFocusStyle: number;
   elementsWithoutFocusStyle: number;
-  /** WCAG 2.4.7 violations */
-  issues: Array<{
-    tag: string;
-    role: string | null;
-    name: string;
-  }>;
+  /** WCAG 2.4.7 findings (no computed-style change on focus) */
+  issues: FocusElementRef[];
   /** WCAG 3.2.1 violations - focus triggered context change */
   onFocusViolations: OnFocusViolation[];
-  /** WCAG 2.4.12 violations - focus obscured by fixed/sticky elements */
+  /** WCAG 2.4.11/2.4.12 findings - focus obscured by fixed/sticky elements */
   focusObscuredIssues: FocusObscuredIssue[];
   elementsWithObscuredFocus: number;
   allElements: FocusRecord[];
@@ -94,8 +174,10 @@ export interface FocusCheckResult {
   screenshotPath: string;
 }
 
+export type FocusCheckResult = AuditCheckResult<FocusCheckDetails>;
+
 // =============================================================================
-// Focus Obscured Types (WCAG 2.4.12)
+// Focus Obscured (WCAG 2.4.11 / 2.4.12)
 // =============================================================================
 
 /**
@@ -126,16 +208,11 @@ export interface FocusObscuredOverlap {
 }
 
 /**
- * WCAG 2.4.12 violation - focus indicator hidden by fixed/sticky content
+ * WCAG 2.4.11/2.4.12 finding - focus indicator hidden by fixed/sticky content
  */
 export interface FocusObscuredIssue {
   /** The focused element that is obscured */
-  element: {
-    tag: string;
-    role: string | null;
-    name: string;
-    selector: string;
-  };
+  element: FocusElementRef;
   /** Bounding rect of the focused element */
   elementRect: BoundingRect;
   /** List of overlapping fixed/sticky elements */
@@ -145,12 +222,14 @@ export interface FocusObscuredIssue {
 }
 
 // =============================================================================
-// Reflow Check Types (WCAG 1.4.10)
+// Reflow Check (WCAG 1.4.10)
 // =============================================================================
 
 export interface ReflowIssue {
   selector: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   rect: {
     left: number;
     right: number;
@@ -163,6 +242,8 @@ export interface ReflowIssue {
 export interface ClippedTextElement {
   selector: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   scrollWidth: number;
   clientWidth: number;
   scrollHeight: number;
@@ -171,8 +252,7 @@ export interface ClippedTextElement {
   overflowX: string;
 }
 
-export interface ReflowCheckResult {
-  url: string;
+export interface ReflowCheckDetails {
   viewport: { width: number; height: number };
   hasHorizontalScroll: boolean;
   documentScrollWidth: number;
@@ -181,8 +261,10 @@ export interface ReflowCheckResult {
   clippedTextElements: ClippedTextElement[];
 }
 
+export type ReflowCheckResult = AuditCheckResult<ReflowCheckDetails>;
+
 // =============================================================================
-// Target Size Check Types (WCAG 2.5.5 / 2.5.8)
+// Target Size Check (WCAG 2.5.5 / 2.5.8)
 // =============================================================================
 
 /**
@@ -200,11 +282,26 @@ export type TargetSizeException =
   | 'spacing'
   | 'essential-review';
 
+/**
+ * How thoroughly the SC 2.5.8 exceptions were assessed for a target.
+ * - ruled-out: every exception was checked and none applies — the finding is a
+ *   confirmed violation
+ * - possible: a heuristic matched an exception; needs manual confirmation
+ * - not-assessed: the heuristics found no exception, but they cannot rule out
+ *   the essential exception — needs manual confirmation
+ */
+export type TargetSizeExceptionAssessment =
+  | 'ruled-out'
+  | 'possible'
+  | 'not-assessed';
+
 export interface TargetSizeIssue {
   /** CSS selector for the element */
   selector: string;
   /** HTML tag name */
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   /** ARIA role if present */
   role: string | null;
   /** Computed accessible name */
@@ -221,6 +318,8 @@ export interface TargetSizeIssue {
   exception: TargetSizeException | null;
   /** Human-readable exception details */
   exceptionDetails: string | null;
+  /** Exception-coverage of the assessment (drives violation vs incomplete) */
+  exceptionAssessment: TargetSizeExceptionAssessment;
   /** Link href for redundancy check */
   href: string | null;
 }
@@ -236,9 +335,7 @@ export interface TargetSizeSummary {
   exceptedCount: number;
 }
 
-export interface TargetSizeCheckResult {
-  /** Page URL */
-  url: string;
+export interface TargetSizeCheckDetails {
   /** Total interactive elements checked */
   totalTargetsChecked: number;
   /** Elements failing AA threshold (< 24px) */
@@ -249,17 +346,21 @@ export interface TargetSizeCheckResult {
   passedTargets: number;
   /** Elements with possible exceptions */
   exceptedTargets: TargetSizeIssue[];
-  /** Summary counts */
+  /** Per-target counts */
   summary: TargetSizeSummary;
 }
 
+export type TargetSizeCheckResult = AuditCheckResult<TargetSizeCheckDetails>;
+
 // =============================================================================
-// Text Spacing Check Types (WCAG 1.4.12)
+// Text Spacing Check (WCAG 1.4.12)
 // =============================================================================
 
 export interface TextSpacingIssue {
   selector: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   beforeMetrics: {
     scrollWidth: number;
     scrollHeight: number;
@@ -278,19 +379,22 @@ export interface TextSpacingIssue {
   issueType: 'horizontal-clip' | 'vertical-clip' | 'both';
 }
 
-export interface TextSpacingCheckResult {
-  url: string;
+export interface TextSpacingCheckDetails {
   clippedElements: TextSpacingIssue[];
   totalElementsChecked: number;
 }
 
+export type TextSpacingCheckResult = AuditCheckResult<TextSpacingCheckDetails>;
+
 // =============================================================================
-// Zoom 200% Check Types (WCAG 1.4.4)
+// Zoom 200% Check (WCAG 1.4.4)
 // =============================================================================
 
 export interface ZoomIssue {
   selector: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   scrollWidth: number;
   clientWidth: number;
   scrollHeight: number;
@@ -298,8 +402,7 @@ export interface ZoomIssue {
   issueType: 'horizontal-scroll' | 'clipped-content';
 }
 
-export interface ZoomCheckResult {
-  url: string;
+export interface ZoomCheckDetails {
   zoomFactor: number;
   viewport: { width: number; height: number };
   hasHorizontalScroll: boolean;
@@ -308,8 +411,10 @@ export interface ZoomCheckResult {
   clippedElements: ZoomIssue[];
 }
 
+export type ZoomCheckResult = AuditCheckResult<ZoomCheckDetails>;
+
 // =============================================================================
-// Orientation Check Types (WCAG 1.3.4)
+// Orientation Check (WCAG 1.3.4)
 // =============================================================================
 
 export interface OrientationState {
@@ -321,21 +426,24 @@ export interface OrientationState {
   visibleTextLength: number;
 }
 
-export interface OrientationCheckResult {
-  url: string;
+export interface OrientationCheckDetails {
   portrait: OrientationState;
   landscape: OrientationState;
   hasOrientationLock: boolean;
   lockDetectedIn: 'portrait' | 'landscape' | 'both' | 'none';
 }
 
+export type OrientationCheckResult = AuditCheckResult<OrientationCheckDetails>;
+
 // =============================================================================
-// Autocomplete Audit Types (WCAG 1.3.5)
+// Autocomplete Audit (WCAG 1.3.5)
 // =============================================================================
 
 export interface AutocompleteIssue {
   selector: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
   inputType: string;
   name: string | null;
   id: string | null;
@@ -346,21 +454,24 @@ export interface AutocompleteIssue {
   issueType: 'missing' | 'invalid';
 }
 
-export interface AutocompleteAuditResult {
-  url: string;
+export interface AutocompleteAuditDetails {
   totalFieldsChecked: number;
   missingAutocomplete: AutocompleteIssue[];
   invalidAutocomplete: AutocompleteIssue[];
 }
 
+export type AutocompleteAuditResult = AuditCheckResult<AutocompleteAuditDetails>;
+
 // =============================================================================
-// Time Limit Detector Types (WCAG 2.2.1)
+// Time Limit Detector (WCAG 2.2.1)
 // =============================================================================
 
 export interface MetaRefreshInfo {
   content: string;
   seconds: number;
   url: string | null;
+  html: string;
+  htmlTruncated: boolean;
 }
 
 export interface TimerInfo {
@@ -373,18 +484,21 @@ export interface CountdownIndicator {
   selector: string;
   text: string;
   tagName: string;
+  html: string;
+  htmlTruncated: boolean;
 }
 
-export interface TimeLimitDetectorResult {
-  url: string;
+export interface TimeLimitDetectorDetails {
   metaRefresh: MetaRefreshInfo[];
   timers: TimerInfo[];
   countdownIndicators: CountdownIndicator[];
   hasTimeLimits: boolean;
 }
 
+export type TimeLimitDetectorResult = AuditCheckResult<TimeLimitDetectorDetails>;
+
 // =============================================================================
-// Auto-play Detection Types (WCAG 1.4.2 / 2.2.2)
+// Auto-play Detection (WCAG 1.4.2 / 2.2.2)
 // =============================================================================
 
 export interface ScreenshotRecord {
@@ -434,8 +548,7 @@ export interface PauseVerificationResult {
   error: string | null;
 }
 
-export interface AutoPlayDetectionResult {
-  url: string;
+export interface AutoPlayDetectionDetails {
   screenshotRecords: ScreenshotRecord[];
   comparisons: ComparisonResult[];
   hasAutoPlayContent: boolean;
@@ -444,3 +557,5 @@ export interface AutoPlayDetectionResult {
   pauseVerification: PauseVerificationResult;
   recommendation: string;
 }
+
+export type AutoPlayDetectionResult = AuditCheckResult<AutoPlayDetectionDetails>;

--- a/packages/a11y-audit/src/utils/axe-format.ts
+++ b/packages/a11y-audit/src/utils/axe-format.ts
@@ -1,0 +1,691 @@
+/**
+ * Pure mappers from check-specific `details` to the axe-style buckets
+ * (`violations` / `incomplete` / `passes` / `inapplicable`), plus the envelope
+ * assembler and the opt-in cross-check merge.
+ *
+ * Everything here is browser-independent: the runners gather evidence into a
+ * details object, and these functions derive the normalized view from it.
+ * Because the details objects are part of the saved JSON, the buckets can be
+ * re-derived from a result file at any time.
+ */
+
+import type {
+  AuditCheckResult,
+  AuditResultSummary,
+  AutocompleteAuditDetails,
+  AutoPlayDetectionDetails,
+  CheckSource,
+  FocusCheckDetails,
+  FocusElementRef,
+  NormalizedImpact,
+  NormalizedNode,
+  NormalizedRuleResult,
+  OrientationCheckDetails,
+  ReflowCheckDetails,
+  TargetSizeCheckDetails,
+  TargetSizeIssue,
+  TextSpacingCheckDetails,
+  TimeLimitDetectorDetails,
+  ZoomCheckDetails,
+} from '../types.js';
+import { AUDIT_DISCLAIMER, HTML_SNIPPET_MAX_LENGTH } from '../constants.js';
+import { getRule, type RuleKey } from './rule-registry.js';
+
+// =============================================================================
+// Buckets
+// =============================================================================
+
+export interface NormalizedBuckets {
+  violations: NormalizedRuleResult[];
+  incomplete: NormalizedRuleResult[];
+  passes: NormalizedRuleResult[];
+  inapplicable: NormalizedRuleResult[];
+  /** Number of elements the check examined, when countable. */
+  checkedNodes?: number;
+}
+
+function emptyBuckets(): NormalizedBuckets {
+  return { violations: [], incomplete: [], passes: [], inapplicable: [] };
+}
+
+function ruleResult(key: RuleKey, nodes: NormalizedNode[]): NormalizedRuleResult {
+  const meta = getRule(key);
+  return {
+    id: meta.id,
+    impact: meta.impact,
+    description: meta.description,
+    help: meta.help,
+    helpUrl: meta.helpUrl,
+    tags: [...meta.tags],
+    nodes,
+  };
+}
+
+/**
+ * Route a rule's findings into the right bucket:
+ * not applicable → `inapplicable`, no findings → `passes`, findings →
+ * the registry's classification (or an explicit override).
+ */
+function bucketize(
+  buckets: NormalizedBuckets,
+  key: RuleKey,
+  nodes: NormalizedNode[],
+  applicable: boolean,
+  override?: 'violation' | 'incomplete'
+): void {
+  if (!applicable) {
+    buckets.inapplicable.push(ruleResult(key, []));
+    return;
+  }
+  if (nodes.length === 0) {
+    buckets.passes.push(ruleResult(key, []));
+    return;
+  }
+  const classification = override ?? getRule(key).classification;
+  (classification === 'violation' ? buckets.violations : buckets.incomplete).push(
+    ruleResult(key, nodes)
+  );
+}
+
+// =============================================================================
+// Node helpers
+// =============================================================================
+
+interface ElementEvidence {
+  selector: string;
+  html?: string;
+  htmlTruncated?: boolean;
+  tagName?: string;
+  tag?: string;
+}
+
+/** Build a node from element evidence, synthesizing `html` when missing. */
+function toNode(el: ElementEvidence, failureSummary: string): NormalizedNode {
+  const tag = (el.tagName ?? el.tag ?? 'element').toLowerCase();
+  const html = el.html && el.html.length > 0 ? el.html : `<${tag}>`;
+  return {
+    target: [el.selector],
+    html,
+    htmlTruncated: el.htmlTruncated ?? false,
+    failureSummary,
+  };
+}
+
+/** Build a page-level node (`target: ['html']`). */
+function pageNode(failureSummary: string): NormalizedNode {
+  return { target: ['html'], html: '<html>', htmlTruncated: false, failureSummary };
+}
+
+function describeElement(ref: FocusElementRef): string {
+  return `<${ref.tag.toLowerCase()}> "${ref.name}"`;
+}
+
+// =============================================================================
+// Envelope assembly
+// =============================================================================
+
+/** Assemble the common envelope from a check's details and buckets. */
+export function buildAuditResult<TDetails>(args: {
+  source: CheckSource;
+  url: string;
+  details: TDetails;
+  buckets: NormalizedBuckets;
+  timestamp?: string;
+}): AuditCheckResult<TDetails> {
+  const { source, url, details, buckets, timestamp } = args;
+  const summary: AuditResultSummary = {
+    violationCount: buckets.violations.length,
+    incompleteCount: buckets.incomplete.length,
+    passCount: buckets.passes.length,
+  };
+  if (buckets.checkedNodes !== undefined) {
+    summary.checkedNodes = buckets.checkedNodes;
+  }
+  return {
+    source,
+    url,
+    timestamp: timestamp ?? new Date().toISOString(),
+    violations: buckets.violations,
+    incomplete: buckets.incomplete,
+    passes: buckets.passes,
+    inapplicable: buckets.inapplicable,
+    summary,
+    details,
+    disclaimer: AUDIT_DISCLAIMER,
+  };
+}
+
+// =============================================================================
+// Per-check normalizers
+// =============================================================================
+
+export function normalizeFocusCheck(details: FocusCheckDetails): NormalizedBuckets {
+  const buckets = emptyBuckets();
+  const applicable = details.totalFocusableElements > 0;
+  buckets.checkedNodes = details.totalFocusableElements;
+
+  bucketize(
+    buckets,
+    'focus-visible',
+    details.issues.map((el) =>
+      toNode(
+        el,
+        `${describeElement(el)} shows no computed-style change on focus ` +
+          '(outline, box-shadow, background-color). Verify manually whether a ' +
+          'visual focus indicator exists (pseudo-elements, canvas, or parent ' +
+          'changes are not detected).'
+      )
+    ),
+    applicable
+  );
+
+  bucketize(
+    buckets,
+    'no-context-change-on-focus',
+    details.onFocusViolations.map((v) =>
+      toNode(
+        v.element,
+        `Focusing ${describeElement(v.element)} triggered a ${v.changeType} ` +
+          `from ${v.fromUrl} to ${v.toUrl}.`
+      )
+    ),
+    applicable
+  );
+
+  bucketize(
+    buckets,
+    'focus-not-obscured',
+    details.focusObscuredIssues.map((issue) =>
+      toNode(
+        issue.element,
+        `${describeElement(issue.element)} is ${(issue.obscuredRatio * 100).toFixed(0)}% ` +
+          `obscured when focused (by ${issue.overlaps
+            .map((o) => `<${o.obscuredBy.tag.toLowerCase()}>`)
+            .join(', ')}). Verify whether the focused element is hidden.`
+      )
+    ),
+    applicable
+  );
+
+  return buckets;
+}
+
+export function normalizeReflowCheck(details: ReflowCheckDetails): NormalizedBuckets {
+  const buckets = emptyBuckets();
+
+  const overflowNodes = details.overflowingElements.map((el) =>
+    toNode(
+      el,
+      `<${el.tagName}> extends to ${el.rect.right}px in a ${el.viewportWidth}px ` +
+        `viewport (${el.reason}). Verify whether a two-dimensional layout ` +
+        'exception (table, map, diagram, ...) applies.'
+    )
+  );
+  if (details.hasHorizontalScroll && overflowNodes.length === 0) {
+    overflowNodes.push(
+      pageNode(
+        `Document scrolls horizontally at ${details.viewport.width}px ` +
+          `(scrollWidth ${details.documentScrollWidth}px > clientWidth ` +
+          `${details.documentClientWidth}px). Verify whether an exception applies.`
+      )
+    );
+  }
+  bucketize(buckets, 'reflow-overflow', overflowNodes, true);
+
+  bucketize(
+    buckets,
+    'reflow-clipped-text',
+    details.clippedTextElements.map((el) =>
+      toNode(
+        el,
+        `<${el.tagName}> clips its text at ${details.viewport.width}px ` +
+          `(scrollWidth ${el.scrollWidth}px > clientWidth ${el.clientWidth}px, ` +
+          `overflow: ${el.overflow}). Verify whether content is lost.`
+      )
+    ),
+    true
+  );
+
+  return buckets;
+}
+
+export function normalizeTargetSizeCheck(
+  details: TargetSizeCheckDetails
+): NormalizedBuckets {
+  const buckets = emptyBuckets();
+  const applicable = details.totalTargetsChecked > 0;
+  buckets.checkedNodes = details.totalTargetsChecked;
+
+  const minimumFailureSummary = (issue: TargetSizeIssue): string => {
+    const base =
+      `Target is ${issue.width}x${issue.height}px ` +
+      `(min dimension ${issue.minDimension}px, requirement 24px).`;
+    if (issue.exception) {
+      return (
+        `${base} Possible '${issue.exception}' exception: ` +
+        `${issue.exceptionDetails ?? 'see manual review notes'}. Confirm manually.`
+      );
+    }
+    return `${base} No exception detected, but the essential exception cannot be ruled out automatically.`;
+  };
+
+  // Minimum (2.5.8 AA): findings are fail-aa targets, with and without
+  // detected exceptions. Only 'ruled-out' assessments are confirmed violations.
+  const minimumIssues = [...details.failAA, ...details.exceptedTargets].filter(
+    (issue) => issue.level === 'fail-aa'
+  );
+  const confirmed = minimumIssues.filter(
+    (i) => i.exceptionAssessment === 'ruled-out'
+  );
+  const needsReview = minimumIssues.filter(
+    (i) => i.exceptionAssessment !== 'ruled-out'
+  );
+  if (!applicable) {
+    buckets.inapplicable.push(ruleResult('target-size-minimum', []));
+  } else if (minimumIssues.length === 0) {
+    buckets.passes.push(ruleResult('target-size-minimum', []));
+  } else {
+    if (confirmed.length > 0) {
+      buckets.violations.push(
+        ruleResult(
+          'target-size-minimum',
+          confirmed.map((i) => toNode(i, minimumFailureSummary(i)))
+        )
+      );
+    }
+    if (needsReview.length > 0) {
+      buckets.incomplete.push(
+        ruleResult(
+          'target-size-minimum',
+          needsReview.map((i) => toNode(i, minimumFailureSummary(i)))
+        )
+      );
+    }
+  }
+
+  // Enhanced (2.5.5 AAA): targets that pass AA but miss the 44px requirement.
+  // Targets already failing AA are reported under target-size-minimum only.
+  bucketize(
+    buckets,
+    'target-size-enhanced',
+    details.failAAAOnly.map((issue) =>
+      toNode(
+        issue,
+        `Target is ${issue.width}x${issue.height}px ` +
+          `(min dimension ${issue.minDimension}px, AAA requirement 44px). ` +
+          'Verify whether an SC 2.5.5 exception applies.'
+      )
+    ),
+    applicable
+  );
+
+  return buckets;
+}
+
+export function normalizeTextSpacingCheck(
+  details: TextSpacingCheckDetails
+): NormalizedBuckets {
+  const buckets = emptyBuckets();
+  buckets.checkedNodes = details.totalElementsChecked;
+
+  bucketize(
+    buckets,
+    'text-spacing',
+    details.clippedElements.map((el) =>
+      toNode(
+        el,
+        `<${el.tagName}> clips its content (${el.issueType}) when WCAG 1.4.12 ` +
+          `text spacing is applied: ${el.afterMetrics.scrollWidth}x${el.afterMetrics.scrollHeight}px ` +
+          `content in a ${el.afterMetrics.clientWidth}x${el.afterMetrics.clientHeight}px box.`
+      )
+    ),
+    details.totalElementsChecked > 0
+  );
+
+  return buckets;
+}
+
+export function normalizeZoomCheck(details: ZoomCheckDetails): NormalizedBuckets {
+  const buckets = emptyBuckets();
+
+  const nodes = details.clippedElements.map((el) =>
+    toNode(
+      el,
+      `<${el.tagName}> ${el.issueType === 'horizontal-scroll' ? 'overflows horizontally' : 'clips its content'} ` +
+        `at ${details.zoomFactor * 100}% zoom (scrollWidth ${el.scrollWidth}px > ` +
+        `clientWidth ${el.clientWidth}px). Verify whether content or ` +
+        'functionality is lost.'
+    )
+  );
+  if (details.hasHorizontalScroll && nodes.length === 0) {
+    nodes.push(
+      pageNode(
+        `Document scrolls horizontally at ${details.zoomFactor * 100}% zoom ` +
+          `(scrollWidth ${details.documentScrollWidth}px > clientWidth ` +
+          `${details.documentClientWidth}px). Horizontal scrolling alone does ` +
+          'not fail SC 1.4.4 — verify whether text becomes unusable.'
+      )
+    );
+  }
+  bucketize(buckets, 'resize-text', nodes, true);
+
+  return buckets;
+}
+
+export function normalizeOrientationCheck(
+  details: OrientationCheckDetails
+): NormalizedBuckets {
+  const buckets = emptyBuckets();
+
+  const nodes: NormalizedNode[] = [];
+  if (details.hasOrientationLock) {
+    const state =
+      details.lockDetectedIn === 'landscape' ? details.landscape : details.portrait;
+    const messagePart = state.lockMessageText
+      ? ` Lock message found: "${state.lockMessageText}".`
+      : '';
+    nodes.push(
+      pageNode(
+        `Content appears restricted to a single orientation ` +
+          `(detected in: ${details.lockDetectedIn}).${messagePart} Verify ` +
+          'whether the essential exception (SC 1.3.4) applies.'
+      )
+    );
+  }
+  bucketize(buckets, 'orientation-lock', nodes, true);
+
+  return buckets;
+}
+
+export function normalizeAutocompleteAudit(
+  details: AutocompleteAuditDetails
+): NormalizedBuckets {
+  const buckets = emptyBuckets();
+  const applicable = details.totalFieldsChecked > 0;
+  buckets.checkedNodes = details.totalFieldsChecked;
+
+  bucketize(
+    buckets,
+    'autocomplete-invalid',
+    details.invalidAutocomplete.map((field) =>
+      toNode(
+        field,
+        `autocomplete="${field.currentAutocomplete}" is not a valid token. ` +
+          `Expected "${field.expectedToken}" (purpose matched by ${field.matchedBy}).`
+      )
+    ),
+    applicable
+  );
+
+  bucketize(
+    buckets,
+    'autocomplete-missing',
+    details.missingAutocomplete.map((field) =>
+      toNode(
+        field,
+        `Field appears to collect "${field.expectedToken}" (matched by ` +
+          `${field.matchedBy}) but has ${
+            field.currentAutocomplete === null
+              ? 'no autocomplete attribute'
+              : `autocomplete="${field.currentAutocomplete}"`
+          }. Confirm the field purpose manually.`
+      )
+    ),
+    applicable
+  );
+
+  return buckets;
+}
+
+export function normalizeTimeLimitDetector(
+  details: TimeLimitDetectorDetails
+): NormalizedBuckets {
+  const buckets = emptyBuckets();
+
+  bucketize(
+    buckets,
+    'meta-refresh',
+    details.metaRefresh.map((meta) => ({
+      target: ['meta[http-equiv="refresh"]'],
+      html: meta.html || `<meta http-equiv="refresh" content="${meta.content}">`,
+      htmlTruncated: meta.htmlTruncated ?? false,
+      failureSummary:
+        `Page refreshes${meta.url ? ` to ${meta.url}` : ''} after ${meta.seconds}s. ` +
+        'Verify whether the time limit can be turned off, adjusted, or extended, ' +
+        'or whether an SC 2.2.1 exception (e.g. over 20 hours) applies.',
+    })),
+    true
+  );
+
+  bucketize(
+    buckets,
+    'time-limit-timer',
+    details.timers.map((timer) =>
+      pageNode(
+        `${timer.type} with a ${timer.delayMs}ms delay detected` +
+          `${timer.callStack ? ` (${timer.callStack.split('\n')[0]?.trim()})` : ''}. ` +
+          'Verify whether it implements a time limit and is adjustable.'
+      )
+    ),
+    true
+  );
+
+  bucketize(
+    buckets,
+    'time-limit-countdown',
+    details.countdownIndicators.map((indicator) =>
+      toNode(
+        indicator,
+        `Countdown/timeout wording found: "${indicator.text.slice(0, 80)}". ` +
+          'Verify whether it indicates an adjustable time limit.'
+      )
+    ),
+    true
+  );
+
+  return buckets;
+}
+
+export function normalizeAutoPlayDetection(
+  details: AutoPlayDetectionDetails
+): NormalizedBuckets {
+  const buckets = emptyBuckets();
+
+  const nodes: NormalizedNode[] = [];
+  if (details.hasAutoPlayContent && !details.stopsWithin5Seconds) {
+    const controlsPart = details.pauseControls.found
+      ? `Pause controls found (${details.pauseControls.controls.length}); ` +
+        `pause verified working: ${details.pauseVerification.pauseWorked ?? 'unknown'}.`
+      : 'No pause controls found.';
+    nodes.push(
+      pageNode(
+        `Moving content continues past 5 seconds (pixel-diff detection). ` +
+          `${controlsPart} ${details.recommendation} Verify the content type ` +
+          'and audio manually.'
+      )
+    );
+  }
+  bucketize(buckets, 'auto-play', nodes, true);
+
+  return buckets;
+}
+
+// =============================================================================
+// Axe results normalization
+// =============================================================================
+
+/** Structural subset of an axe-core rule result (avoids a hard axe dependency). */
+export interface RawAxeRule {
+  id: string;
+  impact?: string | null;
+  description: string;
+  help: string;
+  helpUrl: string;
+  tags: string[];
+  nodes: Array<{
+    html: string;
+    target: unknown[];
+    failureSummary?: string | undefined;
+  }>;
+}
+
+export interface RawAxeResults {
+  violations: RawAxeRule[];
+  incomplete: RawAxeRule[];
+  passes: RawAxeRule[];
+  inapplicable: RawAxeRule[];
+}
+
+function normalizeAxeRule(rule: RawAxeRule, includeNodes: boolean): NormalizedRuleResult {
+  return {
+    id: rule.id,
+    impact: (rule.impact ?? null) as NormalizedImpact | null,
+    description: rule.description,
+    help: rule.help,
+    helpUrl: rule.helpUrl,
+    tags: [...rule.tags],
+    nodes: includeNodes
+      ? rule.nodes.map((n) => {
+          const truncated = n.html.length > HTML_SNIPPET_MAX_LENGTH;
+          return {
+            target: n.target.map((t) => String(t)),
+            html: truncated ? n.html.slice(0, HTML_SNIPPET_MAX_LENGTH) : n.html,
+            htmlTruncated: truncated,
+            failureSummary: n.failureSummary ?? '',
+          };
+        })
+      : [],
+  };
+}
+
+/**
+ * Normalize raw axe-core results into the common buckets. Must be fed the RAW
+ * `AxeResults` (before any reduction) — pass/incomplete details are not
+ * recoverable afterwards. Node lists are kept for violations and incomplete;
+ * passes/inapplicable carry rule metadata only.
+ */
+export function normalizeAxeResults(raw: RawAxeResults): NormalizedBuckets {
+  return {
+    violations: raw.violations.map((r) => normalizeAxeRule(r, true)),
+    incomplete: raw.incomplete.map((r) => normalizeAxeRule(r, true)),
+    passes: raw.passes.map((r) => normalizeAxeRule(r, false)),
+    inapplicable: raw.inapplicable.map((r) => normalizeAxeRule(r, false)),
+  };
+}
+
+// =============================================================================
+// Merge (opt-in)
+// =============================================================================
+
+/** Combined view over several checks of the SAME page. */
+export interface MergedAuditResult {
+  url: string;
+  /** Latest timestamp among the merged results. */
+  timestamp: string;
+  sources: CheckSource[];
+  violations: NormalizedRuleResult[];
+  incomplete: NormalizedRuleResult[];
+  passes: NormalizedRuleResult[];
+  inapplicable: NormalizedRuleResult[];
+  summary: AuditResultSummary;
+  disclaimer: typeof AUDIT_DISCLAIMER;
+}
+
+const BUCKETS = ['violations', 'incomplete', 'passes', 'inapplicable'] as const;
+type BucketName = (typeof BUCKETS)[number];
+
+/**
+ * Merge several check results for the same URL into one normalized view.
+ *
+ * - Results with differing URLs are rejected (throws).
+ * - The same rule id is merged into one entry; nodes are deduplicated by
+ *   `target` + `failureSummary`. Identical selectors inside different frames
+ *   or shadow roots are NOT distinguished.
+ * - A rule appearing in several buckets is placed in the highest-priority one:
+ *   violations > incomplete > passes > inapplicable.
+ */
+export function mergeNormalizedResults(
+  results: Array<AuditCheckResult<unknown>>
+): MergedAuditResult {
+  if (results.length === 0) {
+    throw new Error('mergeNormalizedResults requires at least one result.');
+  }
+  const first = results[0]!;
+  const mismatch = results.find((r) => r.url !== first.url);
+  if (mismatch) {
+    throw new Error(
+      `mergeNormalizedResults: URL mismatch — "${first.url}" vs "${mismatch.url}". ` +
+        'Merge only results for the same page.'
+    );
+  }
+
+  interface MergedEntry {
+    bucketIndex: number;
+    rule: NormalizedRuleResult;
+    nodeKeys: Set<string>;
+  }
+  const byId = new Map<string, MergedEntry>();
+  const nodeKey = (n: NormalizedNode): string =>
+    `${JSON.stringify(n.target)}|${n.failureSummary}`;
+
+  for (const result of results) {
+    BUCKETS.forEach((bucket: BucketName, bucketIndex) => {
+      for (const rule of result[bucket]) {
+        let entry = byId.get(rule.id);
+        if (!entry) {
+          entry = {
+            bucketIndex,
+            rule: { ...rule, nodes: [] },
+            nodeKeys: new Set(),
+          };
+          byId.set(rule.id, entry);
+        }
+        entry.bucketIndex = Math.min(entry.bucketIndex, bucketIndex);
+        for (const node of rule.nodes) {
+          const key = nodeKey(node);
+          if (!entry.nodeKeys.has(key)) {
+            entry.nodeKeys.add(key);
+            entry.rule.nodes.push(node);
+          }
+        }
+      }
+    });
+  }
+
+  const merged: Record<BucketName, NormalizedRuleResult[]> = {
+    violations: [],
+    incomplete: [],
+    passes: [],
+    inapplicable: [],
+  };
+  for (const entry of byId.values()) {
+    merged[BUCKETS[entry.bucketIndex]!].push(entry.rule);
+  }
+
+  const latestTimestamp = results
+    .map((r) => r.timestamp)
+    .sort()
+    .at(-1)!;
+  const checkedNodes = results.reduce<number | undefined>((sum, r) => {
+    if (r.summary.checkedNodes === undefined) return sum;
+    return (sum ?? 0) + r.summary.checkedNodes;
+  }, undefined);
+
+  const summary: AuditResultSummary = {
+    violationCount: merged.violations.length,
+    incompleteCount: merged.incomplete.length,
+    passCount: merged.passes.length,
+  };
+  if (checkedNodes !== undefined) {
+    summary.checkedNodes = checkedNodes;
+  }
+
+  return {
+    url: first.url,
+    timestamp: latestTimestamp,
+    sources: [...new Set(results.map((r) => r.source))],
+    ...merged,
+    summary,
+    disclaimer: AUDIT_DISCLAIMER,
+  };
+}

--- a/packages/a11y-audit/src/utils/layout.ts
+++ b/packages/a11y-audit/src/utils/layout.ts
@@ -10,6 +10,8 @@ export interface LayoutCheckOptions {
   overflowTolerance: number;
   checkSelector: string;
   allowedOverflowSelectors: readonly string[];
+  /** Maximum length of captured outerHTML snippets. */
+  htmlSnippetMaxLength: number;
 }
 
 export interface LayoutCheckResult {
@@ -30,7 +32,24 @@ export function createLayoutChecker(options: LayoutCheckOptions): LayoutCheckRes
     overflowTolerance,
     checkSelector,
     allowedOverflowSelectors,
+    htmlSnippetMaxLength,
   } = options;
+
+  function getHtmlSnippet(element: Element): { html: string; htmlTruncated: boolean } {
+    let html = '';
+    try {
+      html = element.outerHTML || '';
+    } catch {
+      html = '';
+    }
+    if (!html) {
+      return { html: `<${element.tagName.toLowerCase()}>`, htmlTruncated: false };
+    }
+    if (html.length > htmlSnippetMaxLength) {
+      return { html: html.slice(0, htmlSnippetMaxLength), htmlTruncated: true };
+    }
+    return { html, htmlTruncated: false };
+  }
 
   // Helper functions (must be defined inside for browser context)
   /**
@@ -116,6 +135,7 @@ export function createLayoutChecker(options: LayoutCheckOptions): LayoutCheckRes
       overflowingElements.push({
         selector,
         tagName: element.tagName.toLowerCase(),
+        ...getHtmlSnippet(element),
         rect: {
           left: Math.round(rect.left),
           right: Math.round(rect.right),
@@ -131,6 +151,7 @@ export function createLayoutChecker(options: LayoutCheckOptions): LayoutCheckRes
       overflowingElements.push({
         selector,
         tagName: element.tagName.toLowerCase(),
+        ...getHtmlSnippet(element),
         rect: {
           left: Math.round(rect.left),
           right: Math.round(rect.right),
@@ -170,6 +191,7 @@ export function createLayoutChecker(options: LayoutCheckOptions): LayoutCheckRes
           clippedTextElements.push({
             selector,
             tagName: element.tagName.toLowerCase(),
+            ...getHtmlSnippet(element),
             scrollWidth,
             clientWidth,
             scrollHeight,

--- a/packages/a11y-audit/src/utils/rule-registry.ts
+++ b/packages/a11y-audit/src/utils/rule-registry.ts
@@ -1,0 +1,267 @@
+/**
+ * Rule metadata registry for the custom (non-axe) checks.
+ *
+ * Single source of truth for rule ids, WCAG mapping, severity, and the
+ * violation/incomplete classification. The mappers in `axe-format.ts` read
+ * from here so that classification policy is reviewable in one place.
+ *
+ * Classification policy: `'violation'` is reserved for rules whose detection
+ * has no blind spot AND where no WCAG exception can apply to a finding.
+ * Heuristic detections and findings with possible exceptions are
+ * `'incomplete'` (the manual-review queue). impact is NOT derived from the
+ * WCAG conformance level; it is assigned per rule, conservatively defaulting
+ * to `moderate`.
+ */
+
+import type { NormalizedImpact } from '../types.js';
+
+export interface RuleMeta {
+  /** Namespaced rule id, e.g. `a11y-skills/focus-visible`. */
+  id: string;
+  /** WCAG success criteria, e.g. `['2.4.7']`. */
+  sc: string[];
+  /**
+   * axe-style tags. The version+level tag reflects the WCAG version that
+   * introduced the SC (2.4.7 → `wcag2aa`, 1.4.10 → `wcag21aa`, ...).
+   */
+  tags: string[];
+  impact: NormalizedImpact;
+  /** Whether findings refer to specific elements or the page as a whole. */
+  scope: 'node' | 'page';
+  description: string;
+  help: string;
+  /** W3C Understanding document URL. */
+  helpUrl: string;
+  /** Default bucket for findings of this rule. */
+  classification: 'violation' | 'incomplete';
+}
+
+const UNDERSTANDING = 'https://www.w3.org/WAI/WCAG22/Understanding';
+
+export const RULES = {
+  // --- focus-indicator-check ---
+  'focus-visible': {
+    id: 'a11y-skills/focus-visible',
+    sc: ['2.4.7'],
+    tags: ['a11y-skills', 'wcag2aa', 'wcag247'],
+    impact: 'serious',
+    scope: 'node',
+    description:
+      'Ensure keyboard focus produces a visible indicator on focusable elements',
+    help: 'Focusable elements should have a visible focus indicator',
+    helpUrl: `${UNDERSTANDING}/focus-visible.html`,
+    // computed-style diffing cannot see pseudo-elements, canvas drawing, or
+    // parent-element changes, so a "no style change" finding is not proof.
+    classification: 'incomplete',
+  },
+  'no-context-change-on-focus': {
+    id: 'a11y-skills/no-context-change-on-focus',
+    sc: ['3.2.1'],
+    tags: ['a11y-skills', 'wcag2a', 'wcag321'],
+    impact: 'serious',
+    scope: 'node',
+    description:
+      'Ensure receiving focus does not trigger a change of context (navigation, new window)',
+    help: 'Focusing an element must not trigger a context change',
+    helpUrl: `${UNDERSTANDING}/on-focus.html`,
+    // the navigation is directly observed, no exception applies.
+    classification: 'violation',
+  },
+  'focus-not-obscured': {
+    id: 'a11y-skills/focus-not-obscured',
+    sc: ['2.4.11', '2.4.12'],
+    tags: ['a11y-skills', 'wcag22aa', 'wcag2411'],
+    impact: 'moderate',
+    scope: 'node',
+    description:
+      'Ensure the focused element is not hidden by fixed or sticky content',
+    help: 'Focused elements should not be obscured by author-created content',
+    helpUrl: `${UNDERSTANDING}/focus-not-obscured-minimum.html`,
+    classification: 'incomplete',
+  },
+
+  // --- reflow-check ---
+  'reflow-overflow': {
+    id: 'a11y-skills/reflow-overflow',
+    sc: ['1.4.10'],
+    tags: ['a11y-skills', 'wcag21aa', 'wcag1410'],
+    impact: 'serious',
+    scope: 'node',
+    description:
+      'Ensure content reflows at 320 CSS px width without horizontal scrolling',
+    help: 'Content should not require horizontal scrolling at 320px width',
+    helpUrl: `${UNDERSTANDING}/reflow.html`,
+    // two-dimensional layout exceptions (tables, maps, ...) need human judgment.
+    classification: 'incomplete',
+  },
+  'reflow-clipped-text': {
+    id: 'a11y-skills/reflow-clipped-text',
+    sc: ['1.4.10'],
+    tags: ['a11y-skills', 'wcag21aa', 'wcag1410'],
+    impact: 'moderate',
+    scope: 'node',
+    description: 'Ensure text is not clipped when content reflows at 320 CSS px',
+    help: 'Text should remain readable at 320px width',
+    helpUrl: `${UNDERSTANDING}/reflow.html`,
+    classification: 'incomplete',
+  },
+
+  // --- target-size-check ---
+  'target-size-minimum': {
+    id: 'a11y-skills/target-size-minimum',
+    sc: ['2.5.8'],
+    tags: ['a11y-skills', 'wcag22aa', 'wcag258'],
+    impact: 'serious',
+    scope: 'node',
+    description: 'Ensure pointer targets are at least 24x24 CSS px (WCAG 2.5.8 AA)',
+    help: 'Pointer targets should be at least 24x24 CSS px',
+    helpUrl: `${UNDERSTANDING}/target-size-minimum.html`,
+    // exception heuristics cannot rule out the essential exception; only
+    // nodes with exceptionAssessment 'ruled-out' are promoted to violations.
+    classification: 'incomplete',
+  },
+  'target-size-enhanced': {
+    id: 'a11y-skills/target-size-enhanced',
+    sc: ['2.5.5'],
+    tags: ['a11y-skills', 'wcag21aaa', 'wcag255'],
+    impact: 'moderate',
+    scope: 'node',
+    description: 'Ensure pointer targets are at least 44x44 CSS px (WCAG 2.5.5 AAA)',
+    help: 'Pointer targets should be at least 44x44 CSS px',
+    helpUrl: `${UNDERSTANDING}/target-size-enhanced.html`,
+    classification: 'incomplete',
+  },
+
+  // --- text-spacing-check ---
+  'text-spacing': {
+    id: 'a11y-skills/text-spacing',
+    sc: ['1.4.12'],
+    tags: ['a11y-skills', 'wcag21aa', 'wcag1412'],
+    impact: 'moderate',
+    scope: 'node',
+    description:
+      'Ensure no loss of content when WCAG 1.4.12 text spacing overrides are applied',
+    help: 'Text must not be clipped under increased text spacing',
+    helpUrl: `${UNDERSTANDING}/text-spacing.html`,
+    // applying the spacing values and observing clipping is the SC's own
+    // mechanical test procedure.
+    classification: 'violation',
+  },
+
+  // --- zoom-200-check ---
+  'resize-text': {
+    id: 'a11y-skills/resize-text',
+    sc: ['1.4.4'],
+    tags: ['a11y-skills', 'wcag2aa', 'wcag144'],
+    impact: 'moderate',
+    scope: 'node',
+    description:
+      'Ensure content remains usable when text is resized to 200%',
+    help: 'Content should not be lost or clipped at 200% zoom',
+    helpUrl: `${UNDERSTANDING}/resize-text.html`,
+    // horizontal scrolling at zoom does not by itself fail SC 1.4.4.
+    classification: 'incomplete',
+  },
+
+  // --- orientation-check ---
+  'orientation-lock': {
+    id: 'a11y-skills/orientation-lock',
+    sc: ['1.3.4'],
+    tags: ['a11y-skills', 'wcag21aa', 'wcag134'],
+    impact: 'serious',
+    scope: 'page',
+    description:
+      'Ensure content does not restrict its view to a single display orientation',
+    help: 'Content should work in both portrait and landscape orientation',
+    helpUrl: `${UNDERSTANDING}/orientation.html`,
+    // the essential exception requires human judgment.
+    classification: 'incomplete',
+  },
+
+  // --- autocomplete-audit ---
+  'autocomplete-invalid': {
+    id: 'a11y-skills/autocomplete-invalid',
+    sc: ['1.3.5'],
+    tags: ['a11y-skills', 'wcag21aa', 'wcag135'],
+    impact: 'moderate',
+    scope: 'node',
+    description: 'Ensure autocomplete attribute values are valid tokens',
+    help: 'autocomplete attributes must use valid token values',
+    helpUrl: `${UNDERSTANDING}/identify-input-purpose.html`,
+    // syntactic validity is machine-checkable.
+    classification: 'violation',
+  },
+  'autocomplete-missing': {
+    id: 'a11y-skills/autocomplete-missing',
+    sc: ['1.3.5'],
+    tags: ['a11y-skills', 'wcag21aa', 'wcag135'],
+    impact: 'moderate',
+    scope: 'node',
+    description:
+      'Ensure fields collecting user information declare their purpose via autocomplete',
+    help: 'Add an autocomplete attribute matching the field purpose',
+    helpUrl: `${UNDERSTANDING}/identify-input-purpose.html`,
+    // field purpose is inferred from name/id/label patterns — heuristic.
+    classification: 'incomplete',
+  },
+
+  // --- time-limit-detector ---
+  'meta-refresh': {
+    id: 'a11y-skills/meta-refresh',
+    sc: ['2.2.1'],
+    tags: ['a11y-skills', 'wcag2a', 'wcag221'],
+    impact: 'serious',
+    scope: 'node',
+    description:
+      'Ensure meta refresh time limits can be turned off, adjusted, or extended',
+    help: 'Verify the meta refresh satisfies an SC 2.2.1 exception or is adjustable',
+    helpUrl: `${UNDERSTANDING}/timing-adjustable.html`,
+    // adjustability / 20-hour exception cannot be determined automatically.
+    classification: 'incomplete',
+  },
+  'time-limit-timer': {
+    id: 'a11y-skills/time-limit-timer',
+    sc: ['2.2.1'],
+    tags: ['a11y-skills', 'wcag2a', 'wcag221'],
+    impact: 'moderate',
+    scope: 'page',
+    description:
+      'Detect JavaScript timers that may implement a time limit',
+    help: 'Verify whether detected timers implement an adjustable time limit',
+    helpUrl: `${UNDERSTANDING}/timing-adjustable.html`,
+    classification: 'incomplete',
+  },
+  'time-limit-countdown': {
+    id: 'a11y-skills/time-limit-countdown',
+    sc: ['2.2.1'],
+    tags: ['a11y-skills', 'wcag2a', 'wcag221'],
+    impact: 'moderate',
+    scope: 'node',
+    description: 'Detect countdown/timeout wording in visible text',
+    help: 'Verify whether the countdown text indicates an adjustable time limit',
+    helpUrl: `${UNDERSTANDING}/timing-adjustable.html`,
+    classification: 'incomplete',
+  },
+
+  // --- auto-play-detection ---
+  'auto-play': {
+    id: 'a11y-skills/auto-play',
+    sc: ['2.2.2', '1.4.2'],
+    tags: ['a11y-skills', 'wcag2a', 'wcag222', 'wcag142'],
+    impact: 'moderate',
+    scope: 'page',
+    description:
+      'Detect auto-playing/moving content lasting longer than 5 seconds without a working pause control',
+    help: 'Moving content over 5 seconds needs a pause, stop, or hide mechanism',
+    helpUrl: `${UNDERSTANDING}/pause-stop-hide.html`,
+    // pixel diffing cannot identify the content type or audio.
+    classification: 'incomplete',
+  },
+} as const satisfies Record<string, RuleMeta>;
+
+export type RuleKey = keyof typeof RULES;
+
+/** Look up a rule's metadata. */
+export function getRule(key: RuleKey): RuleMeta {
+  return RULES[key];
+}

--- a/packages/a11y-audit/src/utils/test-harness.ts
+++ b/packages/a11y-audit/src/utils/test-harness.ts
@@ -8,7 +8,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Page } from '@playwright/test';
-import { AUDIT_DISCLAIMER, DISCLAIMER_CONSOLE } from '../constants.js';
+import { DISCLAIMER_CONSOLE } from '../constants.js';
 
 // =============================================================================
 // Output location resolution
@@ -76,12 +76,12 @@ export function resolveOutputPath(
 export interface SaveResultOptions extends OutputLocationOptions {
   /** Default file name when none is provided via options. */
   defaultFile: string;
-  /** Whether to append the disclaimer to the written JSON (default: true). */
-  includeDisclaimer?: boolean;
 }
 
 /**
  * Save an audit result to a JSON file, creating parent directories as needed.
+ * The result is written as-is — the envelope built by `buildAuditResult()`
+ * already carries the disclaimer.
  *
  * @returns the absolute path the result was written to.
  */
@@ -89,15 +89,11 @@ export function saveAuditResult<T extends object>(
   result: T,
   options: SaveResultOptions
 ): string {
-  const { defaultFile, includeDisclaimer = true, ...location } = options;
+  const { defaultFile, ...location } = options;
   const resolvedPath = resolveOutputPath({ ...location, defaultFile });
 
-  const outputData = includeDisclaimer
-    ? { ...result, disclaimer: AUDIT_DISCLAIMER }
-    : result;
-
   fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
-  fs.writeFileSync(resolvedPath, JSON.stringify(outputData, null, 2));
+  fs.writeFileSync(resolvedPath, JSON.stringify(result, null, 2));
 
   return resolvedPath;
 }

--- a/packages/a11y-audit/test/normalize.spec.ts
+++ b/packages/a11y-audit/test/normalize.spec.ts
@@ -1,0 +1,356 @@
+/**
+ * Unit tests for the pure normalization mappers, the envelope assembler, and
+ * the cross-check merge. No browser needed — fixtures are hand-built details
+ * objects (the same data a runner would gather).
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  buildAuditResult,
+  mergeNormalizedResults,
+  normalizeAutocompleteAudit,
+  normalizeFocusCheck,
+  normalizeTargetSizeCheck,
+  normalizeTextSpacingCheck,
+  normalizeTimeLimitDetector,
+} from '../dist/index.js';
+import type {
+  FocusCheckDetails,
+  TargetSizeCheckDetails,
+  TargetSizeIssue,
+  TextSpacingCheckDetails,
+  TimeLimitDetectorDetails,
+} from '../dist/index.js';
+
+const targetSizeIssue = (
+  overrides: Partial<TargetSizeIssue> = {}
+): TargetSizeIssue => ({
+  selector: '#b1',
+  tagName: 'button',
+  html: '<button id="b1">a</button>',
+  htmlTruncated: false,
+  role: null,
+  accessibleName: 'a',
+  width: 10,
+  height: 10,
+  minDimension: 10,
+  level: 'fail-aa',
+  exception: null,
+  exceptionDetails: null,
+  exceptionAssessment: 'not-assessed',
+  href: null,
+  ...overrides,
+});
+
+const emptyFocusDetails = (
+  overrides: Partial<FocusCheckDetails> = {}
+): FocusCheckDetails => ({
+  totalFocusableElements: 0,
+  elementsWithFocusStyle: 0,
+  elementsWithoutFocusStyle: 0,
+  issues: [],
+  onFocusViolations: [],
+  focusObscuredIssues: [],
+  elementsWithObscuredFocus: 0,
+  allElements: [],
+  interrupted: false,
+  screenshotPath: '',
+  ...overrides,
+});
+
+// =============================================================================
+// Classification boundaries
+// =============================================================================
+
+test('target-size: not-assessed findings go to incomplete, ruled-out to violations', () => {
+  const details: TargetSizeCheckDetails = {
+    totalTargetsChecked: 3,
+    failAA: [
+      targetSizeIssue({ selector: '#review', exceptionAssessment: 'not-assessed' }),
+      targetSizeIssue({ selector: '#confirmed', exceptionAssessment: 'ruled-out' }),
+    ],
+    failAAAOnly: [],
+    passedTargets: 1,
+    exceptedTargets: [],
+    summary: { failAACount: 2, failAAAOnlyCount: 0, passCount: 1, exceptedCount: 0 },
+  };
+
+  const buckets = normalizeTargetSizeCheck(details);
+
+  const violation = buckets.violations.find(
+    (r) => r.id === 'a11y-skills/target-size-minimum'
+  );
+  const incomplete = buckets.incomplete.find(
+    (r) => r.id === 'a11y-skills/target-size-minimum'
+  );
+  expect(violation?.nodes.map((n) => n.target[0])).toEqual(['#confirmed']);
+  expect(incomplete?.nodes.map((n) => n.target[0])).toEqual(['#review']);
+  expect(buckets.checkedNodes).toBe(3);
+});
+
+test('target-size: correct WCAG tags per rule (AA vs AAA)', () => {
+  const details: TargetSizeCheckDetails = {
+    totalTargetsChecked: 2,
+    failAA: [targetSizeIssue()],
+    failAAAOnly: [
+      targetSizeIssue({
+        selector: '#mid',
+        width: 30,
+        height: 30,
+        minDimension: 30,
+        level: 'fail-aaa-only',
+      }),
+    ],
+    passedTargets: 0,
+    exceptedTargets: [],
+    summary: { failAACount: 1, failAAAOnlyCount: 1, passCount: 0, exceptedCount: 0 },
+  };
+
+  const buckets = normalizeTargetSizeCheck(details);
+  const minimum = buckets.incomplete.find(
+    (r) => r.id === 'a11y-skills/target-size-minimum'
+  );
+  const enhanced = buckets.incomplete.find(
+    (r) => r.id === 'a11y-skills/target-size-enhanced'
+  );
+  expect(minimum?.tags).toEqual(
+    expect.arrayContaining(['a11y-skills', 'wcag22aa', 'wcag258'])
+  );
+  expect(enhanced?.tags).toEqual(
+    expect.arrayContaining(['a11y-skills', 'wcag21aaa', 'wcag255'])
+  );
+});
+
+test('focus check: zero focusable elements → all rules inapplicable', () => {
+  const buckets = normalizeFocusCheck(emptyFocusDetails());
+  expect(buckets.violations).toEqual([]);
+  expect(buckets.incomplete).toEqual([]);
+  expect(buckets.passes).toEqual([]);
+  expect(buckets.inapplicable.map((r) => r.id).sort()).toEqual([
+    'a11y-skills/focus-not-obscured',
+    'a11y-skills/focus-visible',
+    'a11y-skills/no-context-change-on-focus',
+  ]);
+});
+
+test('focus check: on-focus navigation is a confirmed violation, missing style is not', () => {
+  const element = {
+    tag: 'A',
+    role: null,
+    name: 'go',
+    selector: '#go',
+    html: '<a id="go" href="/x">go</a>',
+    htmlTruncated: false,
+  };
+  const buckets = normalizeFocusCheck(
+    emptyFocusDetails({
+      totalFocusableElements: 2,
+      elementsWithoutFocusStyle: 1,
+      issues: [element],
+      onFocusViolations: [
+        { element, fromUrl: 'a:b', toUrl: 'a:c', changeType: 'navigation' },
+      ],
+    })
+  );
+
+  expect(buckets.violations.map((r) => r.id)).toEqual([
+    'a11y-skills/no-context-change-on-focus',
+  ]);
+  expect(buckets.incomplete.map((r) => r.id)).toContain(
+    'a11y-skills/focus-visible'
+  );
+  const violation = buckets.violations[0];
+  expect(violation.nodes[0].failureSummary).toContain('navigation');
+});
+
+test('text-spacing clipping is a confirmed violation', () => {
+  const details: TextSpacingCheckDetails = {
+    totalElementsChecked: 5,
+    clippedElements: [
+      {
+        selector: '.box',
+        tagName: 'div',
+        html: '<div class="box">text</div>',
+        htmlTruncated: false,
+        beforeMetrics: { scrollWidth: 80, scrollHeight: 20, clientWidth: 80, clientHeight: 20 },
+        afterMetrics: { scrollWidth: 120, scrollHeight: 20, clientWidth: 80, clientHeight: 20 },
+        overflow: 'hidden',
+        overflowX: 'hidden',
+        overflowY: 'visible',
+        issueType: 'horizontal-clip',
+      },
+    ],
+  };
+  const buckets = normalizeTextSpacingCheck(details);
+  expect(buckets.violations.map((r) => r.id)).toEqual(['a11y-skills/text-spacing']);
+});
+
+test('time-limit: meta refresh and timers are incomplete; timers are page-level', () => {
+  const details: TimeLimitDetectorDetails = {
+    metaRefresh: [
+      {
+        content: '30',
+        seconds: 30,
+        url: null,
+        html: '<meta http-equiv="refresh" content="30">',
+        htmlTruncated: false,
+      },
+    ],
+    timers: [{ type: 'setInterval', delayMs: 60000, callStack: null }],
+    countdownIndicators: [],
+    hasTimeLimits: true,
+  };
+  const buckets = normalizeTimeLimitDetector(details);
+  expect(buckets.violations).toEqual([]);
+  const ids = buckets.incomplete.map((r) => r.id);
+  expect(ids).toContain('a11y-skills/meta-refresh');
+  expect(ids).toContain('a11y-skills/time-limit-timer');
+  const timerRule = buckets.incomplete.find(
+    (r) => r.id === 'a11y-skills/time-limit-timer'
+  );
+  expect(timerRule?.nodes[0].target).toEqual(['html']);
+  expect(timerRule?.nodes[0].html.length).toBeGreaterThan(0);
+});
+
+test('autocomplete: invalid tokens are violations, missing ones incomplete', () => {
+  const field = {
+    selector: '#e',
+    tagName: 'input',
+    html: '<input id="e">',
+    htmlTruncated: false,
+    inputType: 'text',
+    name: 'email',
+    id: 'e',
+    labelText: 'Email',
+    currentAutocomplete: null as string | null,
+    expectedToken: 'email',
+    matchedBy: 'name' as const,
+    issueType: 'missing' as const,
+  };
+  const buckets = normalizeAutocompleteAudit({
+    totalFieldsChecked: 2,
+    missingAutocomplete: [field],
+    invalidAutocomplete: [
+      {
+        ...field,
+        selector: '#bad',
+        currentAutocomplete: 'e-mail',
+        issueType: 'invalid',
+      },
+    ],
+  });
+  expect(buckets.violations.map((r) => r.id)).toEqual([
+    'a11y-skills/autocomplete-invalid',
+  ]);
+  expect(buckets.incomplete.map((r) => r.id)).toEqual([
+    'a11y-skills/autocomplete-missing',
+  ]);
+});
+
+// =============================================================================
+// Envelope contract
+// =============================================================================
+
+test('buildAuditResult derives summary from the buckets and stamps the contract fields', () => {
+  const details: TextSpacingCheckDetails = {
+    totalElementsChecked: 0,
+    clippedElements: [],
+  };
+  const result = buildAuditResult({
+    source: 'text-spacing-check',
+    url: 'about:blank',
+    details,
+    buckets: normalizeTextSpacingCheck(details),
+  });
+
+  expect(result.source).toBe('text-spacing-check');
+  expect(result.url).toBe('about:blank');
+  expect(typeof result.timestamp).toBe('string');
+  expect(result.disclaimer.coverage).toBeDefined();
+  expect(result.summary.violationCount).toBe(result.violations.length);
+  expect(result.summary.incompleteCount).toBe(result.incomplete.length);
+  expect(result.summary.passCount).toBe(result.passes.length);
+});
+
+// =============================================================================
+// Merge invariants
+// =============================================================================
+
+test('mergeNormalizedResults rejects URL mismatches', () => {
+  const details: TextSpacingCheckDetails = {
+    totalElementsChecked: 0,
+    clippedElements: [],
+  };
+  const a = buildAuditResult({
+    source: 'text-spacing-check',
+    url: 'https://example.com/a',
+    details,
+    buckets: normalizeTextSpacingCheck(details),
+  });
+  const b = buildAuditResult({
+    source: 'reflow-check',
+    url: 'https://example.com/b',
+    details,
+    buckets: normalizeTextSpacingCheck(details),
+  });
+  expect(() => mergeNormalizedResults([a, b])).toThrow(/URL mismatch/);
+});
+
+test('mergeNormalizedResults dedupes nodes and applies bucket priority', () => {
+  const mkRule = (nodes: Array<{ sel: string; summary: string }>) => ({
+    id: 'a11y-skills/text-spacing',
+    impact: 'moderate' as const,
+    description: 'd',
+    help: 'h',
+    helpUrl: 'u',
+    tags: ['a11y-skills'],
+    nodes: nodes.map((n) => ({
+      target: [n.sel],
+      html: '<div>',
+      htmlTruncated: false,
+      failureSummary: n.summary,
+    })),
+  });
+  const base = {
+    url: 'https://example.com/',
+    details: {},
+    summary: { violationCount: 0, incompleteCount: 0, passCount: 0 },
+    disclaimer: { message: '', messageEn: '', coverage: '', moreInfo: '' },
+  };
+  const first = {
+    ...base,
+    source: 'text-spacing-check' as const,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    violations: [],
+    incomplete: [mkRule([{ sel: '.a', summary: 's1' }])],
+    passes: [],
+    inapplicable: [],
+  };
+  const second = {
+    ...base,
+    source: 'text-spacing-check' as const,
+    timestamp: '2026-01-02T00:00:00.000Z',
+    violations: [
+      mkRule([
+        { sel: '.a', summary: 's1' }, // duplicate of first's node
+        { sel: '.b', summary: 's2' },
+      ]),
+    ],
+    incomplete: [],
+    passes: [],
+    inapplicable: [],
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const merged = mergeNormalizedResults([first, second] as any);
+
+  // priority: the rule ends up in violations, not incomplete
+  expect(merged.incomplete).toEqual([]);
+  expect(merged.violations).toHaveLength(1);
+  // node '.a'/'s1' deduplicated across results
+  expect(merged.violations[0].nodes.map((n) => n.target[0]).sort()).toEqual([
+    '.a',
+    '.b',
+  ]);
+  expect(merged.timestamp).toBe('2026-01-02T00:00:00.000Z');
+});

--- a/packages/a11y-audit/test/phase2.spec.ts
+++ b/packages/a11y-audit/test/phase2.spec.ts
@@ -17,31 +17,41 @@ import {
 const dataUrl = (html: string) =>
   'data:text/html,' + encodeURIComponent(html);
 
-test('runTextSpacingCheck runs and returns a result shape', async ({
+test('runTextSpacingCheck returns the normalized envelope', async ({
   page,
 }, testInfo) => {
   await page.setContent(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>t</title>
     <style>.box{width:80px;height:20px;overflow:hidden;white-space:nowrap}</style></head>
     <body><div class="box">spacing sensitive text content here</div></body></html>`);
   const result = await runTextSpacingCheck({ page, outputDir: testInfo.outputDir });
-  expect(typeof result.totalElementsChecked).toBe('number');
-  expect(Array.isArray(result.clippedElements)).toBe(true);
+  expect(result.source).toBe('text-spacing-check');
+  expect(typeof result.details.totalElementsChecked).toBe('number');
+  expect(Array.isArray(result.details.clippedElements)).toBe(true);
+  // text-spacing clipping is the SC's own mechanical test → violations bucket
+  if (result.details.clippedElements.length > 0) {
+    expect(result.violations.map((r) => r.id)).toContain(
+      'a11y-skills/text-spacing'
+    );
+  }
 });
 
-test('runZoomCheck detects horizontal scroll at 200%', async ({
+test('runZoomCheck reports horizontal scroll at 200% as incomplete', async ({
   page,
 }, testInfo) => {
   await page.setContent(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>t</title>
     <style>body{margin:0}.wide{width:900px;height:40px;background:#06c}</style></head>
     <body><div class="wide">wide</div></body></html>`);
   const result = await runZoomCheck({ page, outputDir: testInfo.outputDir });
-  expect(result.zoomFactor).toBe(2);
+  expect(result.details.zoomFactor).toBe(2);
   expect(
-    result.hasHorizontalScroll || result.clippedElements.length > 0
+    result.details.hasHorizontalScroll ||
+      result.details.clippedElements.length > 0
   ).toBe(true);
+  expect(result.violations).toEqual([]);
+  expect(result.incomplete.map((r) => r.id)).toContain('a11y-skills/resize-text');
 });
 
-test('runOrientationCheck detects a rotate-device lock message', async ({
+test('runOrientationCheck reports a rotate-device lock as incomplete', async ({
   page,
 }, testInfo) => {
   const url = dataUrl(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>t</title></head>
@@ -51,20 +61,31 @@ test('runOrientationCheck detects a rotate-device lock message', async ({
     targetUrl: url,
     outputDir: testInfo.outputDir,
   });
-  expect(result.hasOrientationLock).toBe(true);
+  expect(result.details.hasOrientationLock).toBe(true);
+  const lock = result.incomplete.find(
+    (r) => r.id === 'a11y-skills/orientation-lock'
+  );
+  expect(lock).toBeDefined();
+  // page-level finding
+  expect(lock!.nodes[0].target).toEqual(['html']);
 });
 
-test('runAutocompleteAudit flags a missing autocomplete', async ({
+test('runAutocompleteAudit flags a missing autocomplete as incomplete', async ({
   page,
 }, testInfo) => {
   await page.setContent(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>t</title></head>
     <body><form><label for="e">Email</label><input id="e" name="email" type="text"></form></body></html>`);
   const result = await runAutocompleteAudit({ page, outputDir: testInfo.outputDir });
-  expect(result.totalFieldsChecked).toBeGreaterThan(0);
-  expect(result.missingAutocomplete.length).toBeGreaterThan(0);
+  expect(result.details.totalFieldsChecked).toBeGreaterThan(0);
+  expect(result.details.missingAutocomplete.length).toBeGreaterThan(0);
+  const missing = result.incomplete.find(
+    (r) => r.id === 'a11y-skills/autocomplete-missing'
+  );
+  expect(missing).toBeDefined();
+  expect(missing!.nodes[0].html).toContain('input');
 });
 
-test('runTimeLimitDetector detects a meta refresh', async ({
+test('runTimeLimitDetector reports a meta refresh as incomplete', async ({
   page,
 }, testInfo) => {
   const url = dataUrl(`<!doctype html><html lang="en"><head><meta charset="utf-8">
@@ -75,11 +96,14 @@ test('runTimeLimitDetector detects a meta refresh', async ({
     settleMs: 200,
     outputDir: testInfo.outputDir,
   });
-  expect(result.hasTimeLimits).toBe(true);
-  expect(result.metaRefresh.length).toBeGreaterThan(0);
+  expect(result.details.hasTimeLimits).toBe(true);
+  expect(result.details.metaRefresh.length).toBeGreaterThan(0);
+  // meta refresh needs an adjustability/exception check → incomplete
+  expect(result.violations).toEqual([]);
+  expect(result.incomplete.map((r) => r.id)).toContain('a11y-skills/meta-refresh');
 });
 
-test('runAutoPlayDetection reports no change on a static page', async ({
+test('runAutoPlayDetection passes on a static page', async ({
   page,
 }, testInfo) => {
   await page.setContent(`<!doctype html><html lang="en"><head><meta charset="utf-8"><title>t</title></head>
@@ -88,6 +112,7 @@ test('runAutoPlayDetection reports no change on a static page', async ({
     page,
     outputDir: testInfo.outputDir,
   });
-  expect(result.hasAutoPlayContent).toBe(false);
-  expect(typeof result.recommendation).toBe('string');
+  expect(result.details.hasAutoPlayContent).toBe(false);
+  expect(typeof result.details.recommendation).toBe('string');
+  expect(result.passes.map((r) => r.id)).toContain('a11y-skills/auto-play');
 });

--- a/packages/a11y-audit/test/schema-validation.spec.ts
+++ b/packages/a11y-audit/test/schema-validation.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * Validates that envelopes produced by the builders conform to the published
+ * JSON Schemas (ajv, draft 2020-12), and that the pre-0.3.0 flat result shape
+ * is rejected.
+ */
+
+import { test, expect } from '@playwright/test';
+import Ajv2020 from 'ajv/dist/2020.js';
+import {
+  buildAuditResult,
+  normalizeAxeResults,
+  normalizeFocusCheck,
+  normalizeReflowCheck,
+  normalizeTargetSizeCheck,
+} from '../dist/index.js';
+import type {
+  FocusCheckDetails,
+  ReflowCheckDetails,
+  TargetSizeCheckDetails,
+} from '../dist/index.js';
+import { RESULT_SCHEMAS } from '../dist/schemas/index.js';
+
+const ajv = new Ajv2020({ strict: false, allowUnionTypes: true });
+
+function expectValid(schemaKey: keyof typeof RESULT_SCHEMAS, data: unknown): void {
+  const validate = ajv.compile(RESULT_SCHEMAS[schemaKey]);
+  const valid = validate(data);
+  expect(
+    valid,
+    JSON.stringify(validate.errors, null, 2)
+  ).toBe(true);
+}
+
+test('axe-audit envelope validates against its schema', () => {
+  const buckets = normalizeAxeResults({
+    violations: [
+      {
+        id: 'image-alt',
+        impact: 'critical',
+        description: 'd',
+        help: 'h',
+        helpUrl: 'https://example.com',
+        tags: ['wcag2a', 'wcag111'],
+        nodes: [
+          {
+            html: '<img src="missing.png">',
+            target: ['img'],
+            failureSummary: 'Fix it',
+          },
+        ],
+      },
+    ],
+    incomplete: [],
+    passes: [],
+    inapplicable: [],
+  });
+  const result = buildAuditResult({
+    source: 'axe-audit',
+    url: 'about:blank',
+    details: {
+      tagsRun: ['wcag2a'],
+      rulesOverride: null,
+      violationRuleCount: 1,
+      passRuleCount: 0,
+      incompleteRuleCount: 0,
+      inapplicableRuleCount: 0,
+    },
+    buckets,
+  });
+  expectValid('axe-audit', result);
+});
+
+test('focus-indicator-check envelope validates against its schema', () => {
+  const element = {
+    tag: 'BUTTON',
+    role: null,
+    name: 'x',
+    selector: '#x',
+    html: '<button id="x">x</button>',
+    htmlTruncated: false,
+  };
+  const details: FocusCheckDetails = {
+    totalFocusableElements: 1,
+    elementsWithFocusStyle: 0,
+    elementsWithoutFocusStyle: 1,
+    issues: [element],
+    onFocusViolations: [],
+    focusObscuredIssues: [],
+    elementsWithObscuredFocus: 0,
+    allElements: [
+      { id: 0, ...element, tag: 'BUTTON', hasFocusStyle: false, diff: {} },
+    ],
+    interrupted: false,
+    screenshotPath: '',
+  };
+  const result = buildAuditResult({
+    source: 'focus-indicator-check',
+    url: 'about:blank',
+    details,
+    buckets: normalizeFocusCheck(details),
+  });
+  expectValid('focus-indicator-check', result);
+});
+
+test('reflow-check envelope validates against its schema', () => {
+  const details: ReflowCheckDetails = {
+    viewport: { width: 320, height: 256 },
+    hasHorizontalScroll: true,
+    documentScrollWidth: 1200,
+    documentClientWidth: 320,
+    overflowingElements: [
+      {
+        selector: 'div:nth-child(1)',
+        tagName: 'div',
+        html: '<div class="wide"></div>',
+        htmlTruncated: false,
+        rect: { left: 0, right: 1200, width: 1200 },
+        viewportWidth: 320,
+        reason: 'overflow-right',
+      },
+    ],
+    clippedTextElements: [],
+  };
+  const result = buildAuditResult({
+    source: 'reflow-check',
+    url: 'about:blank',
+    details,
+    buckets: normalizeReflowCheck(details),
+  });
+  expectValid('reflow-check', result);
+});
+
+test('target-size-check envelope validates against its schema', () => {
+  const details: TargetSizeCheckDetails = {
+    totalTargetsChecked: 1,
+    failAA: [
+      {
+        selector: '#b1',
+        tagName: 'button',
+        html: '<button id="b1">a</button>',
+        htmlTruncated: false,
+        role: null,
+        accessibleName: 'a',
+        width: 10,
+        height: 10,
+        minDimension: 10,
+        level: 'fail-aa',
+        exception: null,
+        exceptionDetails: null,
+        exceptionAssessment: 'not-assessed',
+        href: null,
+      },
+    ],
+    failAAAOnly: [],
+    passedTargets: 0,
+    exceptedTargets: [],
+    summary: { failAACount: 1, failAAAOnlyCount: 0, passCount: 0, exceptedCount: 0 },
+  };
+  const result = buildAuditResult({
+    source: 'target-size-check',
+    url: 'about:blank',
+    details,
+    buckets: normalizeTargetSizeCheck(details),
+  });
+  expectValid('target-size-check', result);
+});
+
+test('the pre-0.3.0 flat result shape is rejected', () => {
+  const legacy = {
+    url: 'about:blank',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    violations: [],
+    passes: 8,
+    incomplete: 1,
+    inapplicable: 50,
+    violationCount: 0,
+  };
+  const validate = ajv.compile(RESULT_SCHEMAS['axe-audit']);
+  expect(validate(legacy)).toBe(false);
+});

--- a/packages/a11y-audit/test/smoke.spec.ts
+++ b/packages/a11y-audit/test/smoke.spec.ts
@@ -51,29 +51,43 @@ const FOCUS_FIXTURE = `<!doctype html>
   <button id="nofocus">no focus indicator</button>
 </body></html>`;
 
-test('runAxeAudit detects violations', async ({ page }, testInfo) => {
+test('runAxeAudit detects violations in the normalized envelope', async ({
+  page,
+}, testInfo) => {
   await page.setContent(AXE_FIXTURE);
   const result = await runAxeAudit({ page, outputDir: testInfo.outputDir });
 
-  expect(result.violationCount).toBeGreaterThan(0);
+  expect(result.source).toBe('axe-audit');
+  expect(result.summary.violationCount).toBeGreaterThan(0);
   // image-alt is a reliable, deterministic violation for the fixture above.
   const ids = result.violations.map((v) => v.id);
   expect(ids).toContain('image-alt');
+  // nodes carry html evidence and selector targets
+  const imageAlt = result.violations.find((v) => v.id === 'image-alt')!;
+  expect(imageAlt.nodes.length).toBeGreaterThan(0);
+  expect(imageAlt.nodes[0].html).toContain('img');
+  expect(imageAlt.nodes[0].target.length).toBeGreaterThan(0);
 });
 
-test('runReflowCheck detects horizontal overflow at 320px', async ({
+test('runReflowCheck reports overflow as incomplete (manual-review queue)', async ({
   page,
 }, testInfo) => {
   await page.setContent(REFLOW_FIXTURE);
   const result = await runReflowCheck({ page, outputDir: testInfo.outputDir });
 
-  expect(result.viewport).toEqual({ width: 320, height: 256 });
+  expect(result.source).toBe('reflow-check');
+  expect(result.details.viewport).toEqual({ width: 320, height: 256 });
   expect(
-    result.hasHorizontalScroll || result.overflowingElements.length > 0
+    result.details.hasHorizontalScroll ||
+      result.details.overflowingElements.length > 0
   ).toBe(true);
+  // reflow findings are never auto-confirmed violations
+  expect(result.violations).toEqual([]);
+  const incompleteIds = result.incomplete.map((r) => r.id);
+  expect(incompleteIds).toContain('a11y-skills/reflow-overflow');
 });
 
-test('runTargetSizeCheck flags undersized adjacent targets', async ({
+test('runTargetSizeCheck flags undersized adjacent targets as incomplete', async ({
   page,
 }, testInfo) => {
   await page.setContent(TARGET_FIXTURE);
@@ -82,11 +96,22 @@ test('runTargetSizeCheck flags undersized adjacent targets', async ({
     outputDir: testInfo.outputDir,
   });
 
-  expect(result.totalTargetsChecked).toBeGreaterThanOrEqual(2);
-  expect(result.summary.failAACount).toBeGreaterThan(0);
+  expect(result.details.totalTargetsChecked).toBeGreaterThanOrEqual(2);
+  expect(result.details.summary.failAACount).toBeGreaterThan(0);
+  expect(result.summary.checkedNodes).toBe(result.details.totalTargetsChecked);
+
+  const minimum = result.incomplete.find(
+    (r) => r.id === 'a11y-skills/target-size-minimum'
+  );
+  expect(minimum).toBeDefined();
+  expect(minimum!.tags).toContain('wcag22aa');
+  expect(minimum!.tags).toContain('wcag258');
+  expect(minimum!.nodes[0].html).toContain('button');
+  // heuristics cannot rule out the essential exception
+  expect(result.details.failAA[0].exceptionAssessment).not.toBe('ruled-out');
 });
 
-test('runFocusIndicatorCheck flags missing focus indicator', async ({
+test('runFocusIndicatorCheck flags missing focus indicator as incomplete', async ({
   browser,
 }, testInfo) => {
   const targetUrl = 'data:text/html,' + encodeURIComponent(FOCUS_FIXTURE);
@@ -96,6 +121,13 @@ test('runFocusIndicatorCheck flags missing focus indicator', async ({
     outputDir: testInfo.outputDir,
   });
 
-  expect(result.totalFocusableElements).toBeGreaterThan(0);
-  expect(result.elementsWithoutFocusStyle).toBeGreaterThan(0);
+  expect(result.details.totalFocusableElements).toBeGreaterThan(0);
+  expect(result.details.elementsWithoutFocusStyle).toBeGreaterThan(0);
+
+  const focusVisible = result.incomplete.find(
+    (r) => r.id === 'a11y-skills/focus-visible'
+  );
+  expect(focusVisible).toBeDefined();
+  expect(focusVisible!.nodes[0].target[0]).toContain('#nofocus');
+  expect(focusVisible!.nodes[0].html).toContain('button');
 });

--- a/skills/auditing-wcag/references/output-format.ja.md
+++ b/skills/auditing-wcag/references/output-format.ja.md
@@ -24,12 +24,34 @@
 | ファイル | 説明 |
 |----------|------|
 | `report.md` | メイン監査レポート（Markdown） |
-| `axe-result.json` | axe-core生結果 |
-| `*.json` | その他スクリプト結果 |
+| `axe-result.json` | axe-core結果（共通envelope形式） |
+| `*-result.json` | その他スクリプト結果（同じ共通envelope形式） |
 | `screenshots/` | 証跡スクリーンショット |
 
 ### 4. スクリプト出力のコピー
 生成されたJSONファイルとスクリーンショットを出力ディレクトリに移動する。
+
+## 結果JSONの形式（@a11y-skills/audit 0.3.0+）
+
+すべてのスクリプト結果は axe 風の共通 envelope で保存される:
+
+- `source` / `url` / `timestamp` — 検査の識別情報
+- `violations[]` — **確定した違反**（検出に死角がなく例外が適用され得ないもののみ）
+- `incomplete[]` — **要手動確認**。ヒューリスティック検出や例外判断が必要な検出は
+  すべてここに入る。**ノイズではなく手動確認キューとして必ずレビューする**
+- `passes[]` / `inapplicable[]` — 問題なし / 検査対象なしのルール
+- `summary` — ルール単位の件数（`violationCount` / `incompleteCount` / `passCount` /
+  `checkedNodes`）
+- `details` — 検査固有の証跡（測定値・スクリーンショットパス・全要素記録など）
+
+各ルールは axe と同じ形（`id` / `impact` / `tags` / `helpUrl` / `nodes[]`）。
+独自ルールの id は `a11y-skills/` 名前空間付き（例: `a11y-skills/focus-visible`）、
+`tags` の `wcag247` 形式タグから該当 SC を機械的に判別できる。
+`nodes[].target` はCSSセレクタ（ページ単位の検出は `['html']`）、`nodes[].html` は
+outerHTML 証跡、`nodes[].failureSummary` は判断理由の説明。
+
+レポート作成時は `violations` を Fail 候補、`incomplete` を手動確認項目として
+基準ごとの判定に反映する。
 
 ## レポートテンプレート
 

--- a/skills/auditing-wcag/references/output-format.md
+++ b/skills/auditing-wcag/references/output-format.md
@@ -24,12 +24,38 @@ Save the following files in the output directory:
 | File | Description |
 |------|-------------|
 | `report.md` | Main audit report (Markdown) |
-| `axe-result.json` | axe-core raw results |
-| `*.json` | Other script results |
+| `axe-result.json` | axe-core results (common envelope format) |
+| `*-result.json` | Other script results (same common envelope format) |
 | `screenshots/` | Evidence screenshots |
 
 ### 4. Copy Script Outputs
 Move generated JSON files and screenshots to the output directory.
+
+## Result JSON Format (@a11y-skills/audit 0.3.0+)
+
+Every script result is saved as the same axe-style envelope:
+
+- `source` / `url` / `timestamp` — identification of the check run
+- `violations[]` — **confirmed violations** (only findings whose detection has
+  no blind spot and where no WCAG exception can apply)
+- `incomplete[]` — **needs manual review**. All heuristic detections and
+  findings with possible exceptions land here. **Treat this bucket as the
+  manual-review queue, never as noise**
+- `passes[]` / `inapplicable[]` — rules with no findings / nothing to examine
+- `summary` — rule-level counts (`violationCount` / `incompleteCount` /
+  `passCount` / `checkedNodes`)
+- `details` — check-specific evidence (measurements, screenshot paths, raw
+  element records)
+
+Each rule is axe-shaped (`id` / `impact` / `tags` / `helpUrl` / `nodes[]`).
+Custom rule ids are namespaced with `a11y-skills/` (e.g.
+`a11y-skills/focus-visible`), and the `wcag247`-style tags identify the
+success criterion mechanically. `nodes[].target` holds CSS selectors
+(page-level findings use `['html']`), `nodes[].html` carries outerHTML
+evidence, and `nodes[].failureSummary` explains the finding.
+
+When writing the report, treat `violations` as Fail candidates and
+`incomplete` as manual-verification items for the per-criterion verdicts.
 
 ## Report Template
 

--- a/skills/auditing-wcag/references/scripts/package.json
+++ b/skills/auditing-wcag/references/scripts/package.json
@@ -25,7 +25,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@a11y-skills/audit": "^0.2.0",
+    "@a11y-skills/audit": "^0.3.0",
     "@playwright/test": "^1.58.0"
   },
   "devDependencies": {

--- a/skills/auditing-wcag/references/scripts/package.json
+++ b/skills/auditing-wcag/references/scripts/package.json
@@ -25,7 +25,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@a11y-skills/audit": "^0.3.0",
+    "@a11y-skills/audit": "^0.2.0",
     "@playwright/test": "^1.58.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Context

`@a11y-skills/audit` の 9 つの独自チェックは、それぞれ独自のフラットな出力形式（`issues` / `failAA` / `overflowingElements` など命名もバラバラ）を返しており、axe-core の `violations[] > nodes[]` 形式とずれていた。消費側（レポート生成・集計）がチェックごとに別ロジックを要するため、**全 10 チェックを axe 風の共通 envelope に統一**する。

パッケージはまだ新しく後方互換性が不要なため、additive ではなく**置き換え方式**を採用。設計は Codex と 4 イテレーションで検討（最終判定 good）。

## 変更内容

### 共通 envelope `AuditCheckResult<TDetails>`
全チェックの戻り値・保存 JSON が `source / url / timestamp / violations / incomplete / passes / inapplicable / summary / details / disclaimer` に統一。各ルールは axe 形式（`id` / `impact` / `tags` / `helpUrl` / `nodes[]`）。旧トップレベル形式は `details` 配下へ移動。

### 保守的な分類（検出 ≠ violation）
確定 violation は「検出に死角がなく例外が適用され得ない」3 種のみ:
- on-focus 文脈変化 (3.2.1)、text-spacing クリップ (1.4.12)、autocomplete 不正トークン (1.3.5)

reflow・zoom・meta refresh・フォーカススタイル欠如・target-size などは全て `incomplete`（要手動確認キュー）。

### 主な追加
- `src/utils/rule-registry.ts` — rule ID 単位のメタデータ固定表（SC ごとに正確な WCAG タグ、target-size は AA/AAA で ID 分離）
- `src/utils/axe-format.ts` — details→4区分の純粋マッパー、`buildAuditResult()`、opt-in の `mergeNormalizedResults()`
- 要素証跡: `html`（outerHTML 300字切り詰め）+ `htmlTruncated`、focus issues に `selector`、`TargetSizeIssue.exceptionAssessment`
- JSON Schema を `$defs` 共通化 + チェック別 details に全面書き換え

## テスト

- ユニット（マッパー分類境界・タグ・merge 不変条件）+ ajv スキーマ実バリデーション = **25 テスト全パス**
- **実機 end-to-end 検証**: 既知の問題 7 種を含むページに対し SKILL のスクリプトを実行 → 全 7 出力が新 envelope で保存、ajv スキーマ全件 PASS、分類が設計通り、`mergeNormalizedResults` で 7 チェックを統合確認

## バージョン

- `@a11y-skills/audit` 0.2.0 → **0.3.0**（破壊的変更だが 0.x なので minor、CHANGELOG に明記）+ ajv を devDep 追加
- プラグイン 2.7.0 → **2.8.0**（出力形式の構造変更）
- README (en/ja)・CHANGELOG・output-format docs（ja 先行→en 同期）更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)