### PR TITLE
chore(auditing-wcag): bump scripts to @a11y-skills/audit ^0.3.0

### DIFF
--- a/skills/auditing-wcag/references/scripts/package-lock.json
+++ b/skills/auditing-wcag/references/scripts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@a11y-skills/audit": "^0.2.0",
+        "@a11y-skills/audit": "^0.3.0",
         "@playwright/test": "^1.58.0"
       },
       "devDependencies": {
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@a11y-skills/audit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@a11y-skills/audit/-/audit-0.2.0.tgz",
-      "integrity": "sha512-JEY65PThW1JOtJn1t+IRAxPIcOSLOy+mN4fY3Sg8fGs0hMBVHai59HZkhQxhDz8yqlQRGG11RQUZxTe50jPl5Q==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@a11y-skills/audit/-/audit-0.3.0.tgz",
+      "integrity": "sha512-vUwADaDtVzkRSwv80+5aS6d1rF+KDSJfTdQZpr3le924IZ6oBQdjVpvi4juMBVTNgJlDY9YcB0Mc1juPP/yCxQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/skills/auditing-wcag/references/scripts/package.json
+++ b/skills/auditing-wcag/references/scripts/package.json
@@ -25,7 +25,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@a11y-skills/audit": "^0.2.0",
+    "@a11y-skills/audit": "^0.3.0",
     "@playwright/test": "^1.58.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Context

[PR #20](https://github.com/masuP9/a11y-specialist-skills/pull/20) で `@a11y-skills/audit` 0.3.0 を npm に公開した（OIDC Trusted Publishing）。これを受けて、WCAG 監査ラッパースクリプトの依存を公開済みの `^0.3.0` へ更新する。

PR #19（axe envelope 統一）の時点では 0.3.0 が未公開だったため、CI の `npm ci` が解決できず一時的に `^0.2.0` のままにしていた。0.3.0 公開により解消。

## 変更内容

- `skills/auditing-wcag/references/scripts/package.json`: `@a11y-skills/audit` を `^0.2.0` → `^0.3.0`
- `package-lock.json` を registry の 0.3.0 で同期

## 検証

- `npm ci` が registry から 0.3.0 を解決（✅）
- `npm run typecheck` 通過（薄いラッパーは結果フィールド非参照のため新 envelope でも問題なし）（✅）

🤖 Generated with [Claude Code](https://claude.com/claude-code)