### PR TITLE
chore: repo hygiene + plugin version-sync CI, release 2.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Accessibility specialist skills for Claude Code and Codex. WCAG 2.2 review, conformance auditing, and improvement planning tools.",
-    "version": "2.8.0"
+    "version": "2.9.0"
   },
   "plugins": [
     {
       "name": "a11y-specialist-skills",
       "description": "Accessibility skills: reviewing-a11y (WCAG reviews), auditing-wcag (conformance audits with automated scripts), planning-wcag-audit (audit planning), planning-a11y-improvement (maturity + roadmap).",
       "source": "./",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "author": {
         "name": "masuP9"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "a11y-specialist-skills",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Accessibility specialist skills for Claude Code and Codex. WCAG 2.2 review, conformance auditing, and improvement planning tools.",
   "author": {
     "name": "masuP9",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "a11y-specialist-skills",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Accessibility specialist skills for WCAG review, conformance auditing, and improvement planning in Codex and Claude Code.",
   "author": {
     "name": "masuP9",

--- a/.github/workflows/plugin-version-check.yml
+++ b/.github/workflows/plugin-version-check.yml
@@ -1,0 +1,43 @@
+name: Plugin version sync
+
+on:
+  pull_request:
+    paths:
+      - '.claude-plugin/**'
+      - '.codex-plugin/**'
+      - '.github/workflows/plugin-version-check.yml'
+  push:
+    branches: [main, master]
+    paths:
+      - '.claude-plugin/**'
+      - '.codex-plugin/**'
+      - '.github/workflows/plugin-version-check.yml'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify plugin version fields match across plugin metadata
+        run: |
+          node -e '
+            const fs = require("fs");
+            const read = (p) => JSON.parse(fs.readFileSync(p, "utf8"));
+            const plugin = read(".claude-plugin/plugin.json");
+            const market = read(".claude-plugin/marketplace.json");
+            const codex = read(".codex-plugin/plugin.json");
+            const versions = {
+              "plugin.json .version": plugin.version,
+              "marketplace.json .metadata.version": market.metadata.version,
+              "marketplace.json .plugins[0].version": market.plugins[0].version,
+              "codex-plugin/plugin.json .version": codex.version,
+            };
+            const unique = new Set(Object.values(versions));
+            if (unique.size !== 1) {
+              console.error("Plugin version mismatch:");
+              for (const [k, v] of Object.entries(versions)) console.error(`  ${k}: ${v}`);
+              process.exit(1);
+            }
+            console.log("Versions in sync:", plugin.version);
+          '

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,12 @@ orientation-screenshot-*.png
 autocomplete-result.json
 time-limit-result.json
 axe-result.json
+
+# Locally-installed agent skills (`npx skills add ...`) — local tooling only,
+# must never ship with the published plugin.
+# Note: `.agents/plugins/` is tracked (Codex marketplace metadata) — only the
+# installer-managed skills subdirectory is ignored.
+.agents/skills/
+.claude/skills/
+/skills/improve
+skills-lock.json


### PR DESCRIPTION
## Summary

- **gitignore locally-installed agent skills**: `npx skills add ...` drops `.agents/skills/`, `.claude/skills/`, a `skills/improve` symlink, and `skills-lock.json` into the working tree. Since everything under `skills/` ships to every plugin user, an accidental `git add -A` would publish an unrelated third-party skill. The installer-managed paths are now ignored; `.agents/plugins/` (tracked Codex marketplace metadata) is deliberately NOT ignored.
- **New CI workflow `plugin-version-check.yml`**: the plugin version lives in **four** places (`.claude-plugin/plugin.json`, two fields in `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`) that must be bumped together per AGENTS.md. The workflow fails if they diverge, triggered on `.claude-plugin/**` / `.codex-plugin/**` changes.
- **Release 2.9.0** (minor): first release including Codex skill support (#22), plus the hygiene/CI changes above.

## Verification

- `git check-ignore -v` matches all four new ignore rules; `.agents/plugins/marketplace.json` is NOT ignored; `git ls-files -i -c --exclude-standard` is empty (no tracked file becomes ignored).
- Version-sync script: `Versions in sync: 2.9.0` (exit 0); exits 1 with a mismatch table when one field is mutated.
- Workflow YAML parses (`js-yaml`).
- `npm run validate:skills`: passes against tracked skills (local-only failure from the untracked `skills/improve` symlink does not apply to CI checkouts — it is exactly the pollution this PR ignores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)