### PR TITLE
ci: cache Playwright browsers keyed by @playwright/test version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,26 @@ jobs:
       - name: Type-check & build
         run: npm run build --workspace @a11y-skills/audit
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+        working-directory: packages/a11y-audit
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+        working-directory: packages/a11y-audit
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
         working-directory: packages/a11y-audit
 
       - name: Run smoke tests
@@ -103,8 +121,24 @@ jobs:
       - name: Type-check (wrappers resolve @a11y-skills/audit)
         run: npm run typecheck
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Run Playwright tests
         run: npm test


### PR DESCRIPTION
## Summary

Both CI jobs (`a11y-audit-package`, `wcag-audit-tests`) were downloading Chromium from scratch (~150–250 MB each) on every run. This PR caches `~/.cache/ms-playwright` with `actions/cache@v4`, keyed by `runner.os` + the `@playwright/test` version resolved from each job's own node_modules tree (the two jobs intentionally use different trees/versions).

- Cache miss → `npx playwright install --with-deps chromium` runs as before
- Cache hit → browser download is skipped; only `npx playwright install-deps chromium` (apt deps, not covered by the cache) runs

When either tree bumps `@playwright/test`, the key changes automatically — no manual invalidation needed.

## Verification

- [x] YAML validated (`npx js-yaml`)
- [ ] First run: both jobs green with cache miss
- [ ] Re-run: both jobs green with `Cache restored from key: playwright-Linux-...`, browser install skipped

Implements plan 002 from `plans/` (improve-skill audit, 2026-06-11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)