### PR TITLE
ci(release): open wrapper bump PR automatically after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,3 +75,73 @@ jobs:
       - name: Publish to npm
         if: github.event_name == 'push' && steps.published.outputs.exists != 'true'
         run: npm publish --workspace @a11y-skills/audit --access public --provenance
+
+  # After a successful tag-push publish, open a PR bumping the auditing-wcag
+  # wrapper scripts to the just-released version. Idempotent: skips when the
+  # wrapper is already on that version.
+  bump-wrapper:
+    needs: publish
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Wait for npm registry propagation
+        run: |
+          VERSION="${GITHUB_REF_NAME#a11y-audit-v}"
+          for i in $(seq 1 10); do
+            if [ "$(npm view "@a11y-skills/audit@$VERSION" version 2>/dev/null)" = "$VERSION" ]; then
+              echo "@a11y-skills/audit@$VERSION is visible on npm."
+              exit 0
+            fi
+            echo "Not visible yet, retry $i/10..."
+            sleep 15
+          done
+          echo "::error::@a11y-skills/audit@$VERSION not visible on npm after 150s"
+          exit 1
+
+      - name: Bump wrapper dependency and lockfile
+        working-directory: skills/auditing-wcag/references/scripts
+        run: |
+          VERSION="${GITHUB_REF_NAME#a11y-audit-v}"
+          CURRENT=$(node -p "require('./package.json').dependencies['@a11y-skills/audit']")
+          if [ "$CURRENT" = "^$VERSION" ]; then
+            echo "Wrapper already on ^$VERSION; nothing to do."
+            echo "SKIP_PR=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          npm pkg set "dependencies.@a11y-skills/audit=^$VERSION"
+          npm install --package-lock-only
+
+      - name: Open bump PR
+        if: env.SKIP_PR != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#a11y-audit-v}"
+          BRANCH="chore/scripts-bump-audit-$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add skills/auditing-wcag/references/scripts/package.json \
+                  skills/auditing-wcag/references/scripts/package-lock.json
+          git commit -m "chore(auditing-wcag): bump scripts to @a11y-skills/audit ^$VERSION"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(auditing-wcag): bump scripts to @a11y-skills/audit ^$VERSION" \
+            --body "Automated follow-up to the \`a11y-audit-v$VERSION\` release: points the auditing-wcag wrapper scripts at the just-published package version.
+
+Note: PRs created with GITHUB_TOKEN do not trigger CI automatically — close/reopen this PR (or push an empty commit) to run CI before merging." \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,10 +138,13 @@ jobs:
                   skills/auditing-wcag/references/scripts/package-lock.json
           git commit -m "chore(auditing-wcag): bump scripts to @a11y-skills/audit ^$VERSION"
           git push origin "$BRANCH"
+          {
+            echo "Automated follow-up to the \`a11y-audit-v$VERSION\` release: points the auditing-wcag wrapper scripts at the just-published package version."
+            echo ""
+            echo "Note: PRs created with GITHUB_TOKEN do not trigger CI automatically — close/reopen this PR (or push an empty commit) to run CI before merging."
+          } > /tmp/bump-pr-body.md
           gh pr create \
             --title "chore(auditing-wcag): bump scripts to @a11y-skills/audit ^$VERSION" \
-            --body "Automated follow-up to the \`a11y-audit-v$VERSION\` release: points the auditing-wcag wrapper scripts at the just-published package version.
-
-Note: PRs created with GITHUB_TOKEN do not trigger CI automatically — close/reopen this PR (or push an empty commit) to run CI before merging." \
+            --body-file /tmp/bump-pr-body.md \
             --base main \
             --head "$BRANCH"

--- a/skills/auditing-wcag/references/scripts/NPM-PACKAGE-NOTE.md
+++ b/skills/auditing-wcag/references/scripts/NPM-PACKAGE-NOTE.md
@@ -11,9 +11,13 @@ defaults.
 
 ## To change a check's behavior
 
-Edit it in `packages/a11y-audit/src/**`, release a new `@a11y-skills/audit`
-version, and bump the dependency in `package.json`. Do **not** reintroduce
-check logic here.
+Edit it in `packages/a11y-audit/src/**` and release a new `@a11y-skills/audit`
+version (push an `a11y-audit-v*` tag). The release workflow's `bump-wrapper`
+job (`.github/workflows/release.yml`) then automatically opens a PR that bumps
+the dependency in this directory's `package.json` / `package-lock.json` —
+review it, close and reopen it once so CI runs (PRs created with
+`GITHUB_TOKEN` don't trigger CI), and merge. Do **not** reintroduce check
+logic here.
 
 ## Running
 


### PR DESCRIPTION
## Summary

Every release of `@a11y-skills/audit` currently requires a manual follow-up PR to bump the wrapper scripts' dependency in `skills/auditing-wcag/references/scripts/package.json` (see 47263e3 → 938b955 for the friction this caused around 0.3.0). This PR adds a `bump-wrapper` job to `release.yml` that opens that PR automatically after a successful tag-push publish.

## How it works

1. `needs: publish` + `if: github.event_name == 'push'` — runs only after a successful publish on a `a11y-audit-v*` tag push; `workflow_dispatch` dry-runs never reach it
2. Polls `npm view @a11y-skills/audit@<version>` (15s × 10) to wait out registry propagation before bumping
3. Idempotency guard: if the wrapper is already on `^<version>`, skips PR creation entirely
4. Otherwise bumps via `npm pkg set` + `npm install --package-lock-only` and opens a PR on branch `chore/scripts-bump-audit-<version>` with the conventional commit message used historically

The existing `publish` job is byte-for-byte unchanged — the diff is additions at the end of the file only.

## Known limitation (deliberate)

PRs created with `GITHUB_TOKEN` don't trigger CI; the auto-created PR's body instructs the maintainer to close/reopen it to run CI before merging. Upgrade path if this becomes annoying: fine-grained PAT or GitHub App token.

## Verification

- [x] YAML validated (`npx js-yaml`)
- [x] Version-extraction logic dry-tested (`a11y-audit-v0.9.9` → `0.9.9`)
- [x] Idempotency guard dry-tested against the real `package.json` (current `^0.3.0` → skip, no mutation)
- [ ] End-to-end: exercised by the next real release tag

Implements plan 003 from `plans/` (improve-skill audit, 2026-06-11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)