### PR TITLE
chore(release): bump @a11y-skills/audit to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1773,7 +1773,7 @@
     },
     "packages/a11y-audit": {
       "name": "@a11y-skills/audit",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",

--- a/packages/a11y-audit/CHANGELOG.md
+++ b/packages/a11y-audit/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `@a11y-skills/audit` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.3.1
+
+### Fixed
+
+- `runFocusIndicatorCheck`: focus-triggered navigations slower than the
+  per-Tab settle window are no longer silently missed. The settle window is
+  now configurable via the new `navigationSettleMs` option (default: 50), and
+  a `framenavigated` listener additionally catches URL changes that commit and
+  revert within a single window. (#26)
+
 ## 0.3.0
 
 **Breaking** — every check now returns (and saves) a single axe-style envelope

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a11y-skills/audit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Playwright + axe-core based WCAG 2.2 accessibility audit functions (axe, focus indicator, reflow, target size, text spacing, zoom, orientation, autocomplete, time limit, auto-play).",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## 概要

`@a11y-skills/audit` のパッチリリース 0.3.0 → 0.3.1。

## 含まれる変更

- **#26**: `runFocusIndicatorCheck` — settle ウィンドウ(50ms)を超えて発火するフォーカス起因ナビゲーションの検出漏れを修正。`navigationSettleMs` オプション追加 + `framenavigated` リスナー

## このPRの変更内容

- `packages/a11y-audit/package.json`: version 0.3.0 → 0.3.1
- `packages/a11y-audit/CHANGELOG.md`: 0.3.1 エントリ追加
- `package-lock.json`: workspace バージョン同期

## マージ後の手順

マージ後にタグ `a11y-audit-v0.3.1` を push すると `release.yml` が npm へ publish し、続けて `bump-wrapper` ジョブ(#25、初回実走)が wrapper スクリプトのバンプ PR を自動作成します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)