### PR TITLE
feat(a11y-audit): a11y-audit bin CLI を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,17 @@ jobs:
       - name: Run smoke tests
         run: npm test --workspace @a11y-skills/audit
 
+      - name: CLI smoke test
+        run: |
+          set +e
+          node packages/a11y-audit/dist/cli.js \
+            --url "file://$PWD/packages/a11y-audit/test/fixtures/cli-smoke.html" \
+            --checks axe-audit --output-dir /tmp/cli-smoke
+          code=$?
+          set -e
+          test "$code" -eq 1
+          test -n "$(ls /tmp/cli-smoke/)"
+
       - name: Verify publish payload
         run: npm publish --workspace @a11y-skills/audit --dry-run
 

--- a/packages/a11y-audit/CHANGELOG.md
+++ b/packages/a11y-audit/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to `@a11y-skills/audit` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased] — 0.4.0
+
+### Added
+
+- `bin` CLI (`a11y-audit`): run all ten WCAG checks against a URL without a
+  Playwright test runner — `npx -y @a11y-skills/audit --url <url>`. Flags:
+  `--checks <list>`, `--output-dir`, `--screenshot`, `--list-checks`,
+  `--version`, `--help`. Exit codes: `0` = no violations, `1` = violations
+  found, `2` = runtime error. JSON output uses the same envelope as the
+  function API regardless of exit code.
+- `test/fixtures/cli-smoke.html`: network-independent smoke fixture (a page
+  with intentional axe violations) for the CI CLI smoke test.
+
 ## 0.3.1
 
 ### Fixed

--- a/packages/a11y-audit/README.ja.md
+++ b/packages/a11y-audit/README.ja.md
@@ -50,6 +50,70 @@ npm install -D pixelmatch pngjs   # runAutoPlayDetection を使う場合のみ
 > ESM 専用です。CommonJS ビルドは同梱しません。ESM（または ESM 出力の TypeScript）から
 > import してください。
 
+## CLI
+
+テストランナー不要で、コマンド 1 本で 10 検査すべてを実行できます。
+
+```sh
+npx -y @a11y-skills/audit --url https://example.com
+```
+
+npm 7 以降では peer dependencies（`@playwright/test`、`@axe-core/playwright`）が
+自動でインストールされます。初回は Chromium のインストールが必要です:
+
+```sh
+npx playwright install chromium
+```
+
+### フラグ
+
+| フラグ | デフォルト | 説明 |
+| --- | --- | --- |
+| `--url <url>` | `TEST_PAGE` 環境変数 | 対象 URL。`--url` が環境変数より優先されます。どちらも未設定の場合は usage を表示して exit 2。 |
+| `--checks <list>` | `all` | カンマ区切りのチェック名（下記一覧参照）。 |
+| `--output-dir <dir>` | `./a11y-audit-results` | 結果 JSON の出力ディレクトリ。 |
+| `--screenshot` | off | focus-indicator のスクリーンショットを有効化。 |
+| `--list-checks` | — | チェック名一覧を出力して exit 0。 |
+| `--version` | — | バージョンを出力して exit 0。 |
+| `--help` | — | usage を出力して exit 0。 |
+
+### チェック名一覧
+
+```
+axe-audit
+focus-indicator-check
+reflow-check
+text-spacing-check
+zoom-200-check
+orientation-check
+autocomplete-audit
+time-limit-detector
+auto-play-detection
+target-size-check
+```
+
+### 終了コード
+
+| コード | 意味 |
+| --- | --- |
+| `0` | すべてのチェックが完了し、違反なし。 |
+| `1` | すべてのチェックが完了し、1 件以上の違反あり。 |
+| `2` | 実行時エラー — 引数不正・peer 欠落・ナビゲーション失敗・チェックのクラッシュ。 |
+
+exit コードが非 0 でも、完了したチェックの JSON は必ず書き出されます。
+
+### peer 要件
+
+`@playwright/test >=1.50.0` および `@axe-core/playwright >=4.10.0` が必要です。
+見つからない場合は exit 2 でインストール手順を案内します。
+`--list-checks`、`--help`、`--version` は peer なしでも動作します。
+
+### `auto-play-detection` と optional deps
+
+`auto-play-detection` は `pixelmatch` と `pngjs` が必要です。
+未インストールの場合はそのチェックだけ `SKIPPED` となり、終了コードには影響しません。
+他の 9 検査は通常通り実行されます。
+
 ## 使い方 — 関数 API（推奨）
 
 ページの遷移は呼び出し側で行い、関数は検査の実行・結果 JSON の書き出し・結果オブジェクトの

--- a/packages/a11y-audit/README.md
+++ b/packages/a11y-audit/README.md
@@ -52,6 +52,70 @@ npm install -D pixelmatch pngjs   # only if you use runAutoPlayDetection
 > ESM only. This package does not ship a CommonJS build; import it from ESM
 > (or a TypeScript project compiled to ESM).
 
+## CLI
+
+Run all ten checks against a URL with a single command — no test runner needed.
+
+```sh
+npx -y @a11y-skills/audit --url https://example.com
+```
+
+Peer dependencies (`@playwright/test`, `@axe-core/playwright`) are pulled in
+automatically by npm 7+. Install Chromium on first use:
+
+```sh
+npx playwright install chromium
+```
+
+### Flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--url <url>` | `TEST_PAGE` env | Target URL. `--url` takes priority over the env var. If neither is set, usage is printed and the process exits 2. |
+| `--checks <list>` | `all` | Comma-separated check names (see list below). |
+| `--output-dir <dir>` | `./a11y-audit-results` | Directory for result JSON files. |
+| `--screenshot` | off | Enable focus-indicator screenshot. |
+| `--list-checks` | — | Print check names and exit 0. |
+| `--version` | — | Print version and exit 0. |
+| `--help` | — | Print usage and exit 0. |
+
+### Available check names
+
+```
+axe-audit
+focus-indicator-check
+reflow-check
+text-spacing-check
+zoom-200-check
+orientation-check
+autocomplete-audit
+time-limit-detector
+auto-play-detection
+target-size-check
+```
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | All checks completed, no violations found. |
+| `1` | All checks completed, at least one violation found. |
+| `2` | Runtime error — bad arguments, missing peers, navigation failure, or check crash. |
+
+Completed-check JSON is always written even when the exit code is non-zero.
+
+### Peer requirements
+
+`@playwright/test >=1.50.0` and `@axe-core/playwright >=4.10.0` must be
+resolvable. If they are not found, the CLI exits 2 with an install hint.
+`--list-checks`, `--help`, and `--version` work without peers.
+
+### `auto-play-detection` and optional deps
+
+`auto-play-detection` needs `pixelmatch` and `pngjs`. If they are absent, that
+check is skipped with a `SKIPPED` message and does not affect the exit code.
+The other nine checks continue normally.
+
 ## Usage — function API (recommended)
 
 You navigate the page; the function runs the check, writes a result JSON, and

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/masuP9/a11y-specialist-skills",
+    "url": "git+https://github.com/masuP9/a11y-specialist-skills.git",
     "directory": "packages/a11y-audit"
   },
   "homepage": "https://github.com/masuP9/a11y-specialist-skills/tree/main/packages/a11y-audit",
@@ -29,6 +29,9 @@
     "reflow",
     "target-size"
   ],
+  "bin": {
+    "a11y-audit": "dist/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/a11y-audit/src/cli.ts
+++ b/packages/a11y-audit/src/cli.ts
@@ -14,6 +14,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { parseArgs } from 'node:util';
+import type { Browser, BrowserContext, Page } from '@playwright/test';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -22,10 +23,8 @@ import { parseArgs } from 'node:util';
 type CheckKind = 'page' | 'browser';
 
 interface RunCheckOptions {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  page: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  browser: any;
+  page: Page;
+  browser: Browser;
   outputDir: string;
   screenshot: boolean;
   url: string;
@@ -344,12 +343,10 @@ async function main(): Promise<void> {
   }
 
   // --- Launch browser ---
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let browser: any;
+  let browser: Browser;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const pw = (await import('@playwright/test')) as any;
-    browser = await pw.chromium.launch();
+    const { chromium } = await import('@playwright/test');
+    browser = await chromium.launch();
   } catch (err) {
     process.stderr.write(
       `Error launching browser: ${err instanceof Error ? err.message : String(err)}\n`,
@@ -376,10 +373,8 @@ async function main(): Promise<void> {
     const start = Date.now();
 
     // page-based checks get a fresh context + navigated page
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let context: any = null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let page: any = null;
+    let context: BrowserContext | null = null;
+    let page: Page | null = null;
 
     try {
       if (check.kind === 'page') {
@@ -405,7 +400,8 @@ async function main(): Promise<void> {
       }
 
       const result = await check.run({
-        page,
+        // page is null only for browser-kind checks, which do not use it
+        page: page as Page,
         browser,
         outputDir,
         screenshot,

--- a/packages/a11y-audit/src/cli.ts
+++ b/packages/a11y-audit/src/cli.ts
@@ -1,0 +1,524 @@
+#!/usr/bin/env node
+/**
+ * @a11y-skills/audit CLI
+ *
+ * Runs WCAG 2.2 accessibility checks against a URL without needing a
+ * Playwright test runner. All 10 checks are available via --checks.
+ *
+ * Exit codes:
+ *   0 — completed, no violations found across all checks
+ *   1 — completed, at least one violation found
+ *   2 — runtime error (bad args, missing peers, navigation failure, check crash)
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { parseArgs } from 'node:util';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type CheckKind = 'page' | 'browser';
+
+interface RunCheckOptions {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  page: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  browser: any;
+  outputDir: string;
+  screenshot: boolean;
+  url: string;
+}
+
+interface AuditResultEnvelope {
+  summary?: {
+    violationCount?: number;
+    incompleteCount?: number;
+    passCount?: number;
+  };
+}
+
+interface CheckEntry {
+  name: string;
+  kind: CheckKind;
+  run: (opts: RunCheckOptions) => Promise<AuditResultEnvelope>;
+}
+
+interface CheckSummary {
+  name: string;
+  status: 'DONE' | 'SKIPPED' | 'ERROR';
+  durationMs: number;
+  violationCount?: number;
+  incompleteCount?: number;
+  passCount?: number;
+  skipReason?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Check registry
+// ---------------------------------------------------------------------------
+
+// Checks are registered with lazy imports to avoid top-level peer resolution.
+const CHECK_REGISTRY: CheckEntry[] = [
+  {
+    name: 'axe-audit',
+    kind: 'page',
+    async run({ page, outputDir }) {
+      const { runAxeAudit } = await import('./playwright/runAxeAudit.js');
+      return (await runAxeAudit({ page, outputDir })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'focus-indicator-check',
+    kind: 'browser',
+    async run({ browser, outputDir, screenshot, url }) {
+      const { runFocusIndicatorCheck } =
+        await import('./playwright/runFocusIndicatorCheck.js');
+      return (await runFocusIndicatorCheck({
+        browser,
+        targetUrl: url,
+        outputDir,
+        screenshot,
+      })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'reflow-check',
+    kind: 'page',
+    async run({ page, outputDir }) {
+      const { runReflowCheck } = await import('./playwright/runReflowCheck.js');
+      return (await runReflowCheck({ page, outputDir })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'text-spacing-check',
+    kind: 'page',
+    async run({ page, outputDir }) {
+      const { runTextSpacingCheck } =
+        await import('./playwright/runTextSpacingCheck.js');
+      return (await runTextSpacingCheck({
+        page,
+        outputDir,
+      })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'zoom-200-check',
+    kind: 'page',
+    async run({ page, outputDir }) {
+      const { runZoomCheck } = await import('./playwright/runZoomCheck.js');
+      return (await runZoomCheck({ page, outputDir })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'orientation-check',
+    kind: 'page',
+    async run({ page, outputDir }) {
+      const { runOrientationCheck } =
+        await import('./playwright/runOrientationCheck.js');
+      return (await runOrientationCheck({
+        page,
+        outputDir,
+      })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'autocomplete-audit',
+    kind: 'page',
+    async run({ page, outputDir }) {
+      const { runAutocompleteAudit } =
+        await import('./playwright/runAutocompleteAudit.js');
+      return (await runAutocompleteAudit({
+        page,
+        outputDir,
+      })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'time-limit-detector',
+    kind: 'page',
+    async run({ page, outputDir }) {
+      const { runTimeLimitDetector } =
+        await import('./playwright/runTimeLimitDetector.js');
+      return (await runTimeLimitDetector({
+        page,
+        outputDir,
+      })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'auto-play-detection',
+    kind: 'page',
+    async run({ page, outputDir }) {
+      const { runAutoPlayDetection } =
+        await import('./playwright/runAutoPlayDetection.js');
+      return (await runAutoPlayDetection({
+        page,
+        outputDir: path.join(outputDir, 'auto-play-screenshots'),
+      })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'target-size-check',
+    kind: 'page',
+    async run({ page, outputDir }) {
+      const { runTargetSizeCheck } =
+        await import('./playwright/runTargetSizeCheck.js');
+      return (await runTargetSizeCheck({
+        page,
+        outputDir,
+      })) as AuditResultEnvelope;
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function printUsage(): void {
+  process.stdout.write(`
+Usage: a11y-audit --url <url> [options]
+
+Options:
+  --url <url>            Target URL to audit. Overrides TEST_PAGE env var.
+  --checks <list>        Comma-separated check names (default: all).
+                         Use --list-checks to see available names.
+  --output-dir <dir>     Directory for result JSON files (default: ./a11y-audit-results).
+  --screenshot           Enable focus-indicator screenshot (default: off).
+  --list-checks          Print available check names and exit.
+  --version              Print version and exit.
+  --help                 Print this message and exit.
+
+Exit codes:
+  0  No violations found.
+  1  One or more violations found.
+  2  Runtime error (bad arguments, missing peers, navigation failure).
+
+Peer requirements:
+  @playwright/test >=1.50.0
+  @axe-core/playwright >=4.10.0
+
+  Install if missing: npm i -D @playwright/test @axe-core/playwright
+  Install browsers:   npx playwright install chromium
+
+auto-play-detection requires optional deps (pixelmatch, pngjs). If they are
+missing, that check is skipped with a SKIPPED notice.
+`);
+}
+
+/** Verify required peers are resolvable. Returns an error string or null. */
+async function checkPeers(): Promise<string | null> {
+  const missing: string[] = [];
+  for (const pkg of ['@playwright/test', '@axe-core/playwright']) {
+    try {
+      await import(pkg);
+    } catch {
+      missing.push(pkg);
+    }
+  }
+  if (missing.length > 0) {
+    return (
+      `Missing required peer dependencies: ${missing.join(', ')}\n` +
+      `Install them with: npm i -D @playwright/test @axe-core/playwright`
+    );
+  }
+  return null;
+}
+
+function formatDuration(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  // Read package version from package.json
+  let pkgVersion = 'unknown';
+  try {
+    const pkgPath = new URL('../package.json', import.meta.url);
+    const pkgJson = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as {
+      version: string;
+    };
+    pkgVersion = pkgJson.version;
+  } catch {
+    // ignore
+  }
+
+  // Parse arguments with explicit types
+  interface ParsedValues {
+    url?: string;
+    checks?: string;
+    'output-dir'?: string;
+    screenshot?: boolean;
+    'list-checks'?: boolean;
+    version?: boolean;
+    help?: boolean;
+  }
+
+  let values: ParsedValues;
+  try {
+    const result = parseArgs({
+      args: process.argv.slice(2),
+      options: {
+        url: { type: 'string' as const },
+        checks: { type: 'string' as const },
+        'output-dir': { type: 'string' as const },
+        screenshot: { type: 'boolean' as const, default: false },
+        'list-checks': { type: 'boolean' as const, default: false },
+        version: { type: 'boolean' as const, default: false },
+        help: { type: 'boolean' as const, default: false },
+      },
+      strict: true,
+    });
+    values = result.values as ParsedValues;
+  } catch (err) {
+    process.stderr.write(
+      `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    printUsage();
+    process.exit(2);
+  }
+
+  if (values.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (values.version) {
+    process.stdout.write(`${pkgVersion}\n`);
+    process.exit(0);
+  }
+
+  if (values['list-checks']) {
+    process.stdout.write(CHECK_REGISTRY.map((c) => c.name).join('\n') + '\n');
+    process.exit(0);
+  }
+
+  // --- Resolve URL ---
+  const url = values.url ?? process.env.TEST_PAGE;
+  if (!url) {
+    process.stderr.write(
+      'Error: --url is required (or set the TEST_PAGE environment variable).\n',
+    );
+    printUsage();
+    process.exit(2);
+  }
+
+  // --- Resolve checks ---
+  const checksArg = values.checks;
+  let selectedChecks: CheckEntry[];
+  if (!checksArg || checksArg === 'all') {
+    selectedChecks = CHECK_REGISTRY;
+  } else {
+    const names = checksArg.split(',').map((n) => n.trim());
+    const unknown = names.filter(
+      (n) => !CHECK_REGISTRY.some((c) => c.name === n),
+    );
+    if (unknown.length > 0) {
+      process.stderr.write(
+        `Error: unknown check(s): ${unknown.join(', ')}\n` +
+          `Run --list-checks to see available names.\n`,
+      );
+      process.exit(2);
+    }
+    selectedChecks = names
+      .map((n) => CHECK_REGISTRY.find((c) => c.name === n))
+      .filter((c): c is CheckEntry => c !== undefined);
+  }
+
+  const outputDir = path.resolve(
+    values['output-dir'] ?? './a11y-audit-results',
+  );
+  const screenshot = values.screenshot === true;
+
+  // --- Peer check (only before running checks) ---
+  const peerError = await checkPeers();
+  if (peerError) {
+    process.stderr.write(`Error: ${peerError}\n`);
+    process.exit(2);
+  }
+
+  // --- Launch browser ---
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let browser: any;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pw = (await import('@playwright/test')) as any;
+    browser = await pw.chromium.launch();
+  } catch (err) {
+    process.stderr.write(
+      `Error launching browser: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(2);
+  }
+
+  // Ensure output directory exists
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  process.stdout.write(`a11y-audit v${pkgVersion}\n`);
+  process.stdout.write(`URL:        ${url}\n`);
+  process.stdout.write(
+    `Checks:     ${selectedChecks.map((c) => c.name).join(', ')}\n`,
+  );
+  process.stdout.write(`Output dir: ${outputDir}\n`);
+  process.stdout.write(`\n`);
+
+  const summaries: CheckSummary[] = [];
+  let hasViolations = false;
+  let hasErrors = false;
+
+  for (const check of selectedChecks) {
+    const start = Date.now();
+
+    // page-based checks get a fresh context + navigated page
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let context: any = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let page: any = null;
+
+    try {
+      if (check.kind === 'page') {
+        context = await browser.newContext();
+        page = await context.newPage();
+
+        // Use 'load' for file: URLs to avoid networkidle hanging
+        const waitUntil = url.startsWith('file:') ? 'load' : 'networkidle';
+        try {
+          await page.goto(url, { waitUntil });
+        } catch (navErr) {
+          const msg = navErr instanceof Error ? navErr.message : String(navErr);
+          process.stderr.write(`[${check.name}] Navigation failed: ${msg}\n`);
+          summaries.push({
+            name: check.name,
+            status: 'ERROR',
+            durationMs: Date.now() - start,
+            error: msg,
+          });
+          hasErrors = true;
+          continue;
+        }
+      }
+
+      const result = await check.run({
+        page,
+        browser,
+        outputDir,
+        screenshot,
+        url,
+      });
+
+      const durationMs = Date.now() - start;
+      const summary = result.summary;
+
+      const violationCount = summary?.violationCount ?? 0;
+      const incompleteCount = summary?.incompleteCount ?? 0;
+      const passCount = summary?.passCount ?? 0;
+
+      if (violationCount > 0) {
+        hasViolations = true;
+      }
+
+      process.stdout.write(
+        `[${check.name}] DONE in ${formatDuration(durationMs)} — ` +
+          `violations: ${violationCount}, passes: ${passCount}, incomplete: ${incompleteCount}\n`,
+      );
+
+      summaries.push({
+        name: check.name,
+        status: 'DONE',
+        durationMs,
+        violationCount,
+        incompleteCount,
+        passCount,
+      });
+    } catch (err) {
+      const durationMs = Date.now() - start;
+      const msg = err instanceof Error ? err.message : String(err);
+
+      // auto-play-detection: optional dep missing → SKIPPED, not ERROR
+      const isOptionalDepMissing =
+        check.name === 'auto-play-detection' &&
+        (msg.includes('pixelmatch') ||
+          msg.includes('pngjs') ||
+          msg.includes('Cannot find module') ||
+          msg.includes('ERR_MODULE_NOT_FOUND'));
+
+      if (isOptionalDepMissing) {
+        process.stdout.write(
+          `[${check.name}] SKIPPED — optional deps missing (pixelmatch, pngjs). ` +
+            `Install with: npm i pixelmatch pngjs\n`,
+        );
+        summaries.push({
+          name: check.name,
+          status: 'SKIPPED',
+          durationMs,
+          skipReason: 'optional deps missing (pixelmatch, pngjs)',
+        });
+      } else {
+        process.stderr.write(`[${check.name}] ERROR: ${msg}\n`);
+        summaries.push({
+          name: check.name,
+          status: 'ERROR',
+          durationMs,
+          error: msg,
+        });
+        hasErrors = true;
+      }
+    } finally {
+      if (context !== null) {
+        try {
+          await context.close();
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    }
+  }
+
+  // --- Close browser ---
+  try {
+    await browser.close();
+  } catch {
+    // ignore
+  }
+
+  // --- Summary ---
+  const totalMs = summaries.reduce((acc, s) => acc + s.durationMs, 0);
+  const doneCount = summaries.filter((s) => s.status === 'DONE').length;
+  const skippedCount = summaries.filter((s) => s.status === 'SKIPPED').length;
+  const errorCount = summaries.filter((s) => s.status === 'ERROR').length;
+  const totalViolations = summaries.reduce(
+    (acc, s) => acc + (s.violationCount ?? 0),
+    0,
+  );
+
+  process.stdout.write(`\n`);
+  process.stdout.write(
+    `--- Summary (${formatDuration(totalMs)}) ---\n` +
+      `  Checks run:   ${doneCount}\n` +
+      `  Skipped:      ${skippedCount}\n` +
+      `  Errors:       ${errorCount}\n` +
+      `  Total violations: ${totalViolations}\n` +
+      `  Results written to: ${outputDir}\n`,
+  );
+
+  if (hasErrors) {
+    process.exit(2);
+  } else if (hasViolations) {
+    process.exit(1);
+  } else {
+    process.exit(0);
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `Fatal error: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(2);
+});

--- a/packages/a11y-audit/test/fixtures/cli-smoke.html
+++ b/packages/a11y-audit/test/fixtures/cli-smoke.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CLI Smoke Test Fixture</title>
+  </head>
+  <body>
+    <h1>Smoke test</h1>
+    <!-- axe violation: img without alt -->
+    <img
+      src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+    />
+    <!-- axe violation: input without label -->
+    <input type="text" id="name-field" />
+  </body>
+</html>


### PR DESCRIPTION
## 概要

`@a11y-skills/audit` に `bin` CLI（`a11y-audit`）を追加します（Plan 008 / 007 スパイクのオプション A）。Playwright テストランナーなしで、1 コマンドで 10 チェックすべてを実行できます。

```sh
npx -y @a11y-skills/audit --url https://example.com
```

007 スパイクでは「需要シグナルのイシュー 3 件待ち」で保留としていましたが、親スキル（auditing-wcag）自身が最初の CLI 利用者になれるという内部需要で上書きしました。将来のスキル移行（Plan 009）が完了すれば、ラッパー 10 本 + バンプ自動化の引退につながります。

## 変更内容

- **`packages/a11y-audit/src/cli.ts`（新規）**: 10 チェックのレジストリ（page ベース 9 + browser ベース 1 を `kind` で中央処理）、`node:util` の `parseArgs`（新規依存ゼロ）、ランタイムのピア確認、`file:` スキーム時の `waitUntil: 'load'` フォールバック
- **`package.json`**: `"bin": { "a11y-audit": "dist/cli.js" }` 追加（`npm pkg fix` による `repository.url` 正規化を含む）
- **`.github/workflows/ci.yml`**: ネットワーク非依存の CLI スモークテスト（`file://` フィクスチャ、exit 1 と出力 JSON を検証）
- **`test/fixtures/cli-smoke.html`（新規）**: 違反 3 件の最小フィクスチャ（publish payload には含まれない）
- **README EN/JA**: CLI セクション追加（フラグ表・チェック名一覧・終了コード契約・ピア要件）
- **CHANGELOG**: 0.4.0 エントリ

## 終了コード契約

| Code | 意味 |
|---|---|
| `0` | 全チェック完了、violations なし |
| `1` | 全チェック完了、violations あり |
| `2` | 実行時エラー（引数不正・ピア欠落・ナビゲーション失敗） |

終了コードが非 0 でも、完了したチェックの JSON は必ず書き出されます。

## 検証済み

- 終了コード 4 パターン（violations / 違反なし / URL なし / ナビゲーション失敗）
- browser ベース経路: focus-indicator-check + `--screenshot`（W3C bad demo で JSON + PNG 出力確認)
- JSON エンベロープのフィールド構成がラッパー実行時と同一
- `npm pack` ベースのコールドインストール（npm 7+ で peer 自動取得）と `--legacy-peer-deps` 時の friendly エラー（exit 2)
- `npm publish --dry-run`: `dist/cli.js` が payload に入り、`test/` は入らない
- 既存テスト 26 件パス、lint / format green
- コンパイル後の `dist/cli.js` にトップレベルの playwright インポートなし（型のみインポートは消去済み）

## リリースメモ

- マージ後は **minor バンプ（0.4.0）** で `a11y-audit-v0.4.0` タグからリリース
- リリース後、bump-wrapper 自動化が `bin` フィールド追加で壊れないことを確認（Plan 008 Step 6-3）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
