### PR TITLE
chore(release): @a11y-skills/audit 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1773,8 +1773,11 @@
     },
     "packages/a11y-audit": {
       "name": "@a11y-skills/audit",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
+      "bin": {
+        "a11y-audit": "dist/cli.js"
+      },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",
         "@playwright/test": "^1.50.0",

--- a/packages/a11y-audit/CHANGELOG.md
+++ b/packages/a11y-audit/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `@a11y-skills/audit` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased] — 0.4.0
+## 0.4.0 — 2026-06-12
 
 ### Added
 

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a11y-skills/audit",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Playwright + axe-core based WCAG 2.2 accessibility audit functions (axe, focus indicator, reflow, target size, text spacing, zoom, orientation, autocomplete, time limit, auto-play).",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## 概要

`@a11y-skills/audit` を **0.4.0**（minor）にバンプします。PR #30 で追加した `bin` CLI（`a11y-audit`）のリリースです。

## 変更内容

- `packages/a11y-audit/package.json`: `0.3.1` → `0.4.0`
- `package-lock.json`: バージョン同期 + `bin` エントリの追従
- `packages/a11y-audit/CHANGELOG.md`: `[Unreleased] — 0.4.0` を `0.4.0 — 2026-06-12` に確定

## マージ後の手順

1. タグ `a11y-audit-v0.4.0` をマージコミットに付与して push → `release.yml` が npm に publish（OIDC）
2. publish 後、bump-wrapper ジョブがラッパーの依存バンプ PR（`^0.4.0`）を自動作成 → close/reopen で CI を回してマージ
3. `bin` フィールド追加で bump-wrapper 自動化が壊れないことを確認（Plan 008 Step 6-3）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
