### PR TITLE
docs(a11y-audit): README に GitHub Actions ワークフロースニペットを追加

### DIFF
--- a/packages/a11y-audit/README.ja.md
+++ b/packages/a11y-audit/README.ja.md
@@ -114,6 +114,57 @@ exit コードが非 0 でも、完了したチェックの JSON は必ず書き
 未インストールの場合はそのチェックだけ `SKIPPED` となり、終了コードには影響しません。
 他の 9 検査は通常通り実行されます。
 
+### GitHub Actions
+
+手動トリガーで監査を実行するコピー&ペースト用ワークフロー。violations があるとジョブは fail する（終了コード 1）。結果を情報提供のみにしたい場合は監査ステップに `continue-on-error: true` を付ける。
+
+```yaml
+# .github/workflows/a11y-audit.yml
+name: A11y Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: 'Audit target URL'
+        required: true
+        default: 'https://example.com'
+
+jobs:
+  a11y-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install audit package
+        run: npm install --no-save @a11y-skills/audit @playwright/test @axe-core/playwright
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run a11y audit
+        run: npx a11y-audit --url "$TARGET_URL" --output-dir a11y-audit-results
+        env:
+          TARGET_URL: ${{ inputs.target_url }}
+
+      - name: Upload audit results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: a11y-audit-results
+          path: a11y-audit-results/
+          retention-days: 30
+```
+
+Notes:
+
+- `push` / `schedule` トリガー（URL はハードコード）を追加すると、定期的なゲートとして実行できる。
+- 結果 JSON ファイル（`--screenshot` 指定時はフォーカスインジケーターのスクリーンショットも含む）はビルドアーティファクトとしてアップロードされる。
+- 繰り返し実行を高速化するには、インストール済みの `@playwright/test` バージョンをキーに `~/.cache/ms-playwright` をキャッシュする — パターンはこのリポジトリの `ci.yml` を参照。
+
 ## 使い方 — 関数 API（推奨）
 
 ページの遷移は呼び出し側で行い、関数は検査の実行・結果 JSON の書き出し・結果オブジェクトの

--- a/packages/a11y-audit/README.md
+++ b/packages/a11y-audit/README.md
@@ -116,6 +116,63 @@ resolvable. If they are not found, the CLI exits 2 with an install hint.
 check is skipped with a `SKIPPED` message and does not affect the exit code.
 The other nine checks continue normally.
 
+### GitHub Actions
+
+Copy-paste workflow for a manually triggered audit. Violations fail the job
+(exit code 1); add `continue-on-error: true` to the audit step if you want the
+result to be informational only.
+
+```yaml
+# .github/workflows/a11y-audit.yml
+name: A11y Audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: 'Audit target URL'
+        required: true
+        default: 'https://example.com'
+
+jobs:
+  a11y-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Install audit package
+        run: npm install --no-save @a11y-skills/audit @playwright/test @axe-core/playwright
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run a11y audit
+        run: npx a11y-audit --url "$TARGET_URL" --output-dir a11y-audit-results
+        env:
+          TARGET_URL: ${{ inputs.target_url }}
+
+      - name: Upload audit results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: a11y-audit-results
+          path: a11y-audit-results/
+          retention-days: 30
+```
+
+Notes:
+
+- Add `push` / `schedule` triggers (with a hardcoded URL) to run the audit as
+  a recurring gate.
+- Result JSON files (and the focus-indicator screenshot when `--screenshot`
+  is set) are uploaded as a build artifact.
+- To speed up repeat runs, cache `~/.cache/ms-playwright` keyed on the
+  installed `@playwright/test` version — see this repository's `ci.yml` for
+  the pattern.
+
 ## Usage — function API (recommended)
 
 You navigate the page; the function runs the check, writes a result JSON, and


### PR DESCRIPTION
## 概要

007 スパイクの即時実施項目（オプション c）です。`packages/a11y-audit` の README（EN/JA）の CLI セクションに、コピー&ペースト用の GitHub Actions ワークフロースニペット `### GitHub Actions` を追加します。

スパイク時の下書きは Playwright 関数 API を heredoc のインライン ESM スクリプトで呼ぶ複雑なものでしたが、0.4.0 で `a11y-audit` CLI が出たため `npx a11y-audit --url <url>` ベースの 6 ステップ構成まで簡略化しています。

## 変更内容

- `packages/a11y-audit/README.md` / `README.ja.md`（計 +108 行、ドキュメントのみ）
- スニペット構成: `workflow_dispatch`（URL 入力付き）→ `setup-node@v6` (Node 24) → `npm install --no-save` → Playwright ブラウザインストール → `npx a11y-audit` → `upload-artifact@v7` で結果をアップロード
- actions のバージョンは PR #33 で揃えた Node 24 系と整合
- 補足 3 点（push/schedule トリガー化、結果 JSON のアーティファクト、ブラウザキャッシュのパターンは本リポジトリ `ci.yml` 参照）も両言語に記載

## 検証済み

- EN/JA の YAML ブロックが byte 単位で同一
- YAML として valid（js-yaml）、`run: |` の列 0 問題なし（マルチライン run 不使用）
- スニペットが参照する CLI フラグ（`--output-dir` 等）が 0.4.0 の `--help` に実在
- prettier / eslint green

`.github/workflows/` への実ワークフロー追加はしていません（ドキュメントのみ）。リリース不要（パッケージのコード変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
