### PR TITLE
fix(a11y-audit): ナビゲーションを自前で行うチェックに targetUrl を渡す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,15 +107,16 @@ jobs:
       - name: Run smoke tests
         run: npm test --workspace @a11y-skills/audit
 
-      - name: CLI smoke test
+      - name: CLI smoke test (all checks)
         run: |
           set +e
           node packages/a11y-audit/dist/cli.js \
             --url "file://$PWD/packages/a11y-audit/test/fixtures/cli-smoke.html" \
-            --checks axe-audit --output-dir /tmp/cli-smoke
-          code=$?
+            --checks all --output-dir /tmp/cli-smoke | tee /tmp/cli-smoke-stdout.log
+          code="${PIPESTATUS[0]}"
           set -e
           test "$code" -eq 1
+          grep -E "Errors: +0" /tmp/cli-smoke-stdout.log
           test -n "$(ls /tmp/cli-smoke/)"
 
       - name: Verify publish payload

--- a/packages/a11y-audit/CHANGELOG.md
+++ b/packages/a11y-audit/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `@a11y-skills/audit` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.4.1 — 2026-06-12
+
+### Fixed
+
+- CLI: `orientation-check` and `time-limit-detector` were failing with
+  "No target URL provided" because the registry entries did not pass `targetUrl`
+  to the underlying check functions. Both checks own their own navigation, so the
+  CLI's redundant pre-navigation step is now skipped for these two entries via the
+  new `ownsNavigation: true` flag on `CheckEntry`.
+
 ## 0.4.0 — 2026-06-12
 
 ### Added

--- a/packages/a11y-audit/src/cli.ts
+++ b/packages/a11y-audit/src/cli.ts
@@ -41,6 +41,9 @@ interface AuditResultEnvelope {
 interface CheckEntry {
   name: string;
   kind: CheckKind;
+  /** When true, the check owns its own navigation (page.goto). The main loop
+   *  skips the pre-navigation step and passes a fresh un-navigated page. */
+  ownsNavigation?: boolean;
   run: (opts: RunCheckOptions) => Promise<AuditResultEnvelope>;
 }
 
@@ -114,11 +117,13 @@ const CHECK_REGISTRY: CheckEntry[] = [
   {
     name: 'orientation-check',
     kind: 'page',
-    async run({ page, outputDir }) {
+    ownsNavigation: true,
+    async run({ page, outputDir, url }) {
       const { runOrientationCheck } =
         await import('./playwright/runOrientationCheck.js');
       return (await runOrientationCheck({
         page,
+        targetUrl: url,
         outputDir,
       })) as AuditResultEnvelope;
     },
@@ -138,11 +143,13 @@ const CHECK_REGISTRY: CheckEntry[] = [
   {
     name: 'time-limit-detector',
     kind: 'page',
-    async run({ page, outputDir }) {
+    ownsNavigation: true,
+    async run({ page, outputDir, url }) {
       const { runTimeLimitDetector } =
         await import('./playwright/runTimeLimitDetector.js');
       return (await runTimeLimitDetector({
         page,
+        targetUrl: url,
         outputDir,
       })) as AuditResultEnvelope;
     },
@@ -381,21 +388,24 @@ async function main(): Promise<void> {
         context = await browser.newContext();
         page = await context.newPage();
 
-        // Use 'load' for file: URLs to avoid networkidle hanging
-        const waitUntil = url.startsWith('file:') ? 'load' : 'networkidle';
-        try {
-          await page.goto(url, { waitUntil });
-        } catch (navErr) {
-          const msg = navErr instanceof Error ? navErr.message : String(navErr);
-          process.stderr.write(`[${check.name}] Navigation failed: ${msg}\n`);
-          summaries.push({
-            name: check.name,
-            status: 'ERROR',
-            durationMs: Date.now() - start,
-            error: msg,
-          });
-          hasErrors = true;
-          continue;
+        if (!check.ownsNavigation) {
+          // Use 'load' for file: URLs to avoid networkidle hanging
+          const waitUntil = url.startsWith('file:') ? 'load' : 'networkidle';
+          try {
+            await page.goto(url, { waitUntil });
+          } catch (navErr) {
+            const msg =
+              navErr instanceof Error ? navErr.message : String(navErr);
+            process.stderr.write(`[${check.name}] Navigation failed: ${msg}\n`);
+            summaries.push({
+              name: check.name,
+              status: 'ERROR',
+              durationMs: Date.now() - start,
+              error: msg,
+            });
+            hasErrors = true;
+            continue;
+          }
         }
       }
 


### PR DESCRIPTION
## 概要

CLI 0.4.0 のバグ修正です（Plan 010）。`--checks all` 実行時に `orientation-check` と `time-limit-detector` が「No target URL provided」で ERROR になり exit 2 を返していました。Plan 009（スキル CLI 移行）のエグゼキューターが STOP 条件で検出したものです。

## 原因

両チェック関数はナビゲーションを自前で行う設計で `targetUrl` オプションを取りますが（未指定時は `TEST_PAGE` 環境変数 → 必須エラー）、CLI レジストリが `{ page, outputDir }` しか渡していませんでした。`requireTargetUrl` を使うチェックは 10 中 3 つで、focus-indicator は渡し済み — 漏れはこの 2 つで全部です。

## 変更内容

- `src/cli.ts`: `CheckEntry` に `ownsNavigation?: boolean` を追加。該当 2 チェックに `ownsNavigation: true` + `targetUrl: url` を設定し、CLI の冗長な事前ナビゲーションをスキップ（un-navigated page を渡す設計どおりに)
- `.github/workflows/ci.yml`: CLI スモークを `--checks axe-audit` → **`--checks all`** に拡張し、`Errors: 0` を機械検証（このバグを見逃した検証ギャップの再発防止)。パイプ経由の終了コード取得は `${PIPESTATUS[0]}` を使用（Actions の `run:` は `shell:` 未指定だと pipefail なしのため `$?` では tee の 0 を拾う）
- `CHANGELOG.md`: 0.4.1 エントリ

## 検証済み

- fixture に対する全 10 チェック: **10 DONE / Skipped 0 / Errors 0 / exit 1**（修正前は 8 DONE / 2 ERROR / exit 2）
- `time-limit-detector` の内部 `networkidle` は file:// でハングせず 2.5s で完了
- CI ステップ本体をローカルで `bash -e`（pipefail なし）でシミュレートしてパス
- 既存テスト 26 件・lint・format green

## マージ後

`0.4.1`（patch）としてリリースします。リリース時の bump-wrapper auto-PR は通常どおり処理（main にはまだラッパーが存在するため。Plan 009 で引退予定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
