### PR TITLE
chore(release): @a11y-skills/audit 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1773,7 +1773,7 @@
     },
     "packages/a11y-audit": {
       "name": "@a11y-skills/audit",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "bin": {
         "a11y-audit": "dist/cli.js"

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a11y-skills/audit",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Playwright + axe-core based WCAG 2.2 accessibility audit functions (axe, focus indicator, reflow, target size, text spacing, zoom, orientation, autocomplete, time limit, auto-play).",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## 概要

`@a11y-skills/audit` を **0.4.1**（patch）にバンプします。PR #35 の CLI バグ修正（`orientation-check` / `time-limit-detector` への `targetUrl` 渡し漏れ）のリリースです。CHANGELOG の 0.4.1 エントリは #35 で追加済み。

## マージ後の手順

1. タグ `a11y-audit-v0.4.1` を push → release.yml が npm に publish
2. bump-wrapper の auto-PR を close/reopen → CI → マージ（main にはまだラッパーが存在するため。Plan 009 で引退予定 — これが最後の bump 儀式になる見込み）
3. 0.4.1 公開確認後、Plan 009（スキル CLI 移行）を再開

🤖 Generated with [Claude Code](https://claude.com/claude-code)
