### PR TITLE
feat(a11y-audit): キーボードトラップ (WCAG 2.1.2) チェックを追加

### DIFF
--- a/packages/a11y-audit/CHANGELOG.md
+++ b/packages/a11y-audit/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to `@a11y-skills/audit` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.5.0 — 2026-06-13
+
+### Added
+
+- **`keyboard-trap-check`** (WCAG 2.1.2 No Keyboard Trap): 11th check in the
+  package. Tabs through every focusable element on the page, detects regions
+  where focus cannot escape via a `count+1` window algorithm, and attempts three
+  escape paths (Escape key, Shift+Tab, visible close affordance). Results are
+  classified as:
+  - `violation` (`a11y-skills/no-keyboard-trap`): focus confined with no working
+    exit.
+  - `incomplete` (`a11y-skills/keyboard-trap-needs-review`): an escape path exists
+    but may not be discoverable without documentation (WCAG 2.1.2 exception).
+  - `pass`: proper `role=dialog` + `aria-modal=true` modal with Escape working.
+  - `inapplicable`: page has no focusable elements.
+
+  **Limitations** (see runner source for details): Shadow DOM interiors, iframe
+  contents, `inert`-based traps, and SPA pages that change focusable element
+  counts during the walk are not detected.
+
+  Available via:
+  - CLI: `npx @a11y-skills/audit --checks keyboard-trap-check --url <url>`
+  - Function API: `runKeyboardTrapCheck` from `@a11y-skills/audit/playwright`
+  - Test entry: `@a11y-skills/audit/test-entries/keyboard-trap-check`
+  - Normalizer: `normalizeKeyboardTrapCheck` from `@a11y-skills/audit`
+  - Schema: `RESULT_SCHEMAS['keyboard-trap-check']` from `@a11y-skills/audit/schemas`
+
 ## 0.4.1 — 2026-06-12
 
 ### Fixed

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -84,6 +84,10 @@
     "./test-entries/auto-play-detection": {
       "types": "./dist/test-entries/auto-play-detection.d.ts",
       "import": "./dist/test-entries/auto-play-detection.js"
+    },
+    "./test-entries/keyboard-trap-check": {
+      "types": "./dist/test-entries/keyboard-trap-check.d.ts",
+      "import": "./dist/test-entries/keyboard-trap-check.js"
     }
   },
   "files": [

--- a/packages/a11y-audit/src/cli.ts
+++ b/packages/a11y-audit/src/cli.ts
@@ -3,7 +3,7 @@
  * @a11y-skills/audit CLI
  *
  * Runs WCAG 2.2 accessibility checks against a URL without needing a
- * Playwright test runner. All 10 checks are available via --checks.
+ * Playwright test runner. All 11 checks are available via --checks.
  *
  * Exit codes:
  *   0 — completed, no violations found across all checks
@@ -175,6 +175,20 @@ const CHECK_REGISTRY: CheckEntry[] = [
       return (await runTargetSizeCheck({
         page,
         outputDir,
+      })) as AuditResultEnvelope;
+    },
+  },
+  {
+    name: 'keyboard-trap-check',
+    kind: 'browser',
+    async run({ browser, outputDir, screenshot, url }) {
+      const { runKeyboardTrapCheck } =
+        await import('./playwright/runKeyboardTrapCheck.js');
+      return (await runKeyboardTrapCheck({
+        browser,
+        targetUrl: url,
+        outputDir,
+        screenshot,
       })) as AuditResultEnvelope;
     },
   },

--- a/packages/a11y-audit/src/constants.ts
+++ b/packages/a11y-audit/src/constants.ts
@@ -568,3 +568,18 @@ export const SVG_METADATA_PATTERNS = [
 
 /** Maximum parent levels to check for carousel context */
 export const MAX_PARENT_LEVELS = 5;
+
+// =============================================================================
+// Keyboard Trap Check Constants (WCAG 2.1.2)
+// =============================================================================
+
+/** Tab walk: extra Tab presses beyond `count` focusable elements. */
+export const KEYBOARD_TRAP_SLACK = 10;
+/** Upper bound on Tab presses per walk (large-page guard). Exceeded count is logged. */
+export const KEYBOARD_TRAP_MAX_TAB_PRESSES = 600;
+/** Wait (ms) after each escape attempt before re-reading activeElement. */
+export const KEYBOARD_TRAP_ESCAPE_SETTLE_MS = 200;
+/** Maximum escape attempts per trap candidate. */
+export const KEYBOARD_TRAP_MAX_ESCAPE_ATTEMPTS = 3;
+export const DEFAULT_KEYBOARD_TRAP_RESULT_FILE = 'keyboard-trap-result.json';
+export const DEFAULT_KEYBOARD_TRAP_SCREENSHOT_FILE = 'keyboard-trap.png';

--- a/packages/a11y-audit/src/index.ts
+++ b/packages/a11y-audit/src/index.ts
@@ -32,6 +32,7 @@ export {
   normalizeAutocompleteAudit,
   normalizeAutoPlayDetection,
   normalizeFocusCheck,
+  normalizeKeyboardTrapCheck,
   normalizeOrientationCheck,
   normalizeReflowCheck,
   normalizeTargetSizeCheck,

--- a/packages/a11y-audit/src/playwright/index.ts
+++ b/packages/a11y-audit/src/playwright/index.ts
@@ -47,6 +47,10 @@ export {
   runAutoPlayDetection,
   type RunAutoPlayDetectionOptions,
 } from './runAutoPlayDetection.js';
+export {
+  runKeyboardTrapCheck,
+  type RunKeyboardTrapCheckOptions,
+} from './runKeyboardTrapCheck.js';
 
 export {
   resolveOutputPath,

--- a/packages/a11y-audit/src/playwright/runKeyboardTrapCheck.ts
+++ b/packages/a11y-audit/src/playwright/runKeyboardTrapCheck.ts
@@ -1,0 +1,547 @@
+/**
+ * Keyboard Trap Check (WCAG 2.1.2 — No Keyboard Trap)
+ *
+ * Tabs through every focusable element on the page and detects regions where
+ * focus cannot escape. Like the focus-indicator check, this owns its
+ * BrowserContext (accepts `browser`, not `page`) so it can perform its own
+ * navigation with `waitUntil: 'load'` for file: URLs (required for CI smoke
+ * tests).
+ *
+ * Limitations:
+ * - Shadow DOM: querySelectorAll does not pierce shadow roots; traps inside
+ *   shadow components are not detected.
+ * - iframes: document.activeElement returns the <iframe> element, not the
+ *   focused descendant; traps inside iframes are not detected.
+ * - Dynamic inert: traps created by toggling the `inert` attribute mid-walk
+ *   are not detected.
+ * - SPA churn: if the number of focusable elements changes during the Tab
+ *   walk the window-size calculation may be off.
+ *
+ * The primary value of this check is as a manual-review filter (incomplete
+ * findings); confirmed violations (no escape at all) are rare but critical.
+ */
+
+import type { Browser, BrowserContextOptions } from '@playwright/test';
+import type {
+  KeyboardTrapCheckResult,
+  KeyboardTrapCheckDetails,
+  KeyboardTrapEvidence,
+} from '../types.js';
+import {
+  FOCUSABLE_SELECTOR,
+  DEFAULT_NAVIGATION_SETTLE_MS,
+  DEFAULT_KEYBOARD_TRAP_RESULT_FILE,
+  DEFAULT_KEYBOARD_TRAP_SCREENSHOT_FILE,
+  KEYBOARD_TRAP_SLACK,
+  KEYBOARD_TRAP_MAX_TAB_PRESSES,
+  KEYBOARD_TRAP_ESCAPE_SETTLE_MS,
+  KEYBOARD_TRAP_MAX_ESCAPE_ATTEMPTS,
+  HTML_SNIPPET_MAX_LENGTH,
+} from '../constants.js';
+import {
+  buildAuditResult,
+  normalizeKeyboardTrapCheck,
+} from '../utils/axe-format.js';
+import {
+  saveAuditResult,
+  takeAuditScreenshot,
+  resolveScreenshotPath,
+  requireTargetUrl,
+  logAuditHeader,
+  logOutputPaths,
+  type OutputLocationOptions,
+} from '../utils/test-harness.js';
+
+// =============================================================================
+// Options
+// =============================================================================
+
+export interface RunKeyboardTrapCheckOptions extends OutputLocationOptions {
+  /** The browser to create audit contexts in. */
+  browser: Browser;
+  /** Target URL. Falls back to the `TEST_PAGE` env var; required. */
+  targetUrl?: string;
+  /** Whether to capture a screenshot (default: false). */
+  screenshot?: boolean;
+  /** Options forwarded to `browser.newContext()`. */
+  contextOptions?: BrowserContextOptions;
+  /** Milliseconds to wait after each Tab press (default: DEFAULT_NAVIGATION_SETTLE_MS). */
+  walkSettleMs?: number;
+}
+
+// =============================================================================
+// Internal types
+// =============================================================================
+
+interface ActiveElementInfo {
+  selector: string;
+  tag: string;
+  name: string;
+  html: string;
+  htmlTruncated: boolean;
+}
+
+// =============================================================================
+// Runner
+// =============================================================================
+
+/**
+ * Run the keyboard trap check, write the result JSON (and optionally a
+ * screenshot), and return the parsed result.
+ */
+export async function runKeyboardTrapCheck(
+  options: RunKeyboardTrapCheckOptions,
+): Promise<KeyboardTrapCheckResult> {
+  const {
+    browser,
+    targetUrl: targetUrlOption,
+    screenshot = false,
+    contextOptions,
+    walkSettleMs = DEFAULT_NAVIGATION_SETTLE_MS,
+    ...location
+  } = options;
+
+  const targetUrl = requireTargetUrl(targetUrlOption);
+
+  const context = await browser.newContext(contextOptions);
+  const page = await context.newPage();
+
+  try {
+    // Use 'load' for file: URLs — networkidle never resolves for file: protocol.
+    const waitUntil = targetUrl.startsWith('file:') ? 'load' : 'networkidle';
+    await page.goto(targetUrl, { waitUntil });
+
+    // ------------------------------------------------------------------
+    // 1. Enumerate focusable elements
+    // ------------------------------------------------------------------
+    const focusableSelector = FOCUSABLE_SELECTOR;
+    const htmlSnippetMaxLength = HTML_SNIPPET_MAX_LENGTH;
+
+    const count: number = await page.evaluate(
+      ({ sel }: { sel: string }) => {
+        return document.querySelectorAll(sel).length;
+      },
+      { sel: focusableSelector },
+    );
+
+    // Early exit: no focusable elements → inapplicable
+    if (count === 0) {
+      const details: KeyboardTrapCheckDetails = {
+        totalFocusableElements: 0,
+        trapCandidates: 0,
+        confirmedTraps: [],
+        needsReview: [],
+        screenshotPath: '',
+      };
+      const buckets = normalizeKeyboardTrapCheck(details);
+      const result = buildAuditResult({
+        source: 'keyboard-trap-check',
+        url: page.url(),
+        details,
+        buckets,
+      });
+
+      let screenshotPathOut = '';
+      if (screenshot) {
+        const resolvedPath = saveAuditResult(result, {
+          ...location,
+          defaultFile: DEFAULT_KEYBOARD_TRAP_RESULT_FILE,
+        });
+        screenshotPathOut = await takeAuditScreenshot(page, {
+          path: resolveScreenshotPath(
+            resolvedPath,
+            DEFAULT_KEYBOARD_TRAP_SCREENSHOT_FILE,
+          ),
+        });
+        details.screenshotPath = screenshotPathOut;
+        logAuditHeader('Keyboard Trap Check', 'WCAG 2.1.2', page.url());
+        logOutputPaths(resolvedPath, screenshotPathOut);
+      } else {
+        const resolvedPath = saveAuditResult(result, {
+          ...location,
+          defaultFile: DEFAULT_KEYBOARD_TRAP_RESULT_FILE,
+        });
+        logAuditHeader('Keyboard Trap Check', 'WCAG 2.1.2', page.url());
+        logOutputPaths(resolvedPath);
+      }
+      return result;
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Tab walk
+    // ------------------------------------------------------------------
+    const pressN = Math.min(
+      2 * count + KEYBOARD_TRAP_SLACK,
+      KEYBOARD_TRAP_MAX_TAB_PRESSES,
+    );
+
+    if (2 * count + KEYBOARD_TRAP_SLACK > KEYBOARD_TRAP_MAX_TAB_PRESSES) {
+      console.warn(
+        `[keyboard-trap-check] Tab walk capped at ${KEYBOARD_TRAP_MAX_TAB_PRESSES} ` +
+          `presses (page has ${count} focusable elements). Large pages may produce ` +
+          `false negatives for traps near the end of the tab order.`,
+      );
+    }
+
+    const walk: string[] = [];
+    const walkDetails: ActiveElementInfo[] = [];
+
+    for (let i = 0; i < pressN; i++) {
+      await page.keyboard.press('Tab');
+      if (walkSettleMs > 0) {
+        await page.waitForTimeout(walkSettleMs);
+      }
+
+      const info: ActiveElementInfo = await page.evaluate(
+        ({ maxLen }: { maxLen: number }) => {
+          const el = document.activeElement;
+          if (!el || el === document.body || el === document.documentElement) {
+            return {
+              selector: '(body)',
+              tag: 'body',
+              name: '',
+              html: '<body>',
+              htmlTruncated: false,
+            };
+          }
+
+          // Build a simple CSS selector for the element
+          function getSelector(element: Element): string {
+            const parts: string[] = [];
+            let current: Element | null = element;
+            while (current && current !== document.documentElement) {
+              const tag = current.tagName.toLowerCase();
+              const id = current.id ? `#${CSS.escape(current.id)}` : '';
+              if (id) {
+                parts.unshift(`${tag}${id}`);
+                break;
+              }
+              const p: Element | null = current.parentElement;
+              if (p) {
+                const siblings = [...p.children].filter(
+                  (c) => c.tagName === current!.tagName,
+                );
+                const idx = siblings.indexOf(current) + 1;
+                parts.unshift(
+                  siblings.length > 1 ? `${tag}:nth-of-type(${idx})` : tag,
+                );
+              } else {
+                parts.unshift(tag);
+              }
+              current = p;
+            }
+            return parts.join(' > ');
+          }
+
+          const selector = getSelector(el);
+          const ariaLabel = (el as HTMLElement).getAttribute('aria-label');
+          const name = ariaLabel
+            ? ariaLabel
+            : (el as HTMLElement).textContent?.trim().slice(0, 50) ?? '';
+
+          const rawHtml = el.outerHTML;
+          const htmlTruncated = rawHtml.length > maxLen;
+
+          return {
+            selector,
+            tag: el.tagName,
+            name,
+            html: htmlTruncated ? rawHtml.slice(0, maxLen) : rawHtml,
+            htmlTruncated,
+          };
+        },
+        { maxLen: htmlSnippetMaxLength },
+      );
+
+      walk.push(info.selector);
+      walkDetails.push(info);
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Trap detection (corrected algorithm: window = count + 1)
+    // ------------------------------------------------------------------
+    const windowSize = count + 1;
+    const tail = walk.slice(-windowSize);
+    const tailSet = new Set(tail);
+
+    const confirmedTraps: KeyboardTrapEvidence[] = [];
+    const needsReview: KeyboardTrapEvidence[] = [];
+
+    // Trap candidate: no (body) in tail, and tail doesn't cover all elements
+    const isTrapCandidate =
+      !tailSet.has('(body)') && tailSet.size < count;
+
+    if (isTrapCandidate) {
+      const trapSelectors = [...tailSet];
+
+      // Find the detail record for each selector
+      const representative: ActiveElementInfo = walkDetails.find(
+        (d) => d.selector === trapSelectors[0],
+      ) ?? {
+        selector: trapSelectors[0] ?? '(unknown)',
+        tag: 'UNKNOWN',
+        name: '',
+        html: `<element>`,
+        htmlTruncated: false,
+      };
+
+      // ------------------------------------------------------------------
+      // 4. Escape path attempts
+      // ------------------------------------------------------------------
+
+      const escapeAttempts = {
+        escape: false,
+        shiftTab: false,
+        closeAffordance: false,
+      };
+
+      // Helper: focus a trap element and try a key or action; return whether
+      // focus moved outside the trap set.
+      async function tryKey(key: string): Promise<boolean> {
+        await page.evaluate(
+          ({ sel }: { sel: string }) => {
+            const el = document.querySelector(sel);
+            if (el instanceof HTMLElement) el.focus();
+          },
+          { sel: representative.selector },
+        );
+        await page.keyboard.press(key);
+        await page.waitForTimeout(KEYBOARD_TRAP_ESCAPE_SETTLE_MS);
+        const afterSel: string = await page.evaluate(() => {
+          const active = document.activeElement;
+          if (
+            !active ||
+            active === document.body ||
+            active === document.documentElement
+          ) {
+            return '(body)';
+          }
+          function getSelector(element: Element): string {
+            const parts: string[] = [];
+            let current: Element | null = element;
+            while (current && current !== document.documentElement) {
+              const tag = current.tagName.toLowerCase();
+              const id = current.id ? `#${CSS.escape(current.id)}` : '';
+              if (id) {
+                parts.unshift(`${tag}${id}`);
+                break;
+              }
+              const p: Element | null = current.parentElement;
+              if (p) {
+                const siblings = [...p.children].filter(
+                  (c) => c.tagName === current!.tagName,
+                );
+                const idx = siblings.indexOf(current) + 1;
+                parts.unshift(
+                  siblings.length > 1 ? `${tag}:nth-of-type(${idx})` : tag,
+                );
+              } else {
+                parts.unshift(tag);
+              }
+              current = p;
+            }
+            return parts.join(' > ');
+          }
+          return getSelector(active);
+        });
+        return afterSel === '(body)' || !tailSet.has(afterSel);
+      }
+
+      let attemptCount = 0;
+
+      // Attempt 1: Escape key
+      if (attemptCount < KEYBOARD_TRAP_MAX_ESCAPE_ATTEMPTS) {
+        escapeAttempts.escape = await tryKey('Escape');
+        attemptCount++;
+      }
+
+      // Attempt 2: Shift+Tab
+      if (attemptCount < KEYBOARD_TRAP_MAX_ESCAPE_ATTEMPTS) {
+        escapeAttempts.shiftTab = await tryKey('Shift+Tab');
+        attemptCount++;
+      }
+
+      // Attempt 3: Visible close affordance
+      if (attemptCount < KEYBOARD_TRAP_MAX_ESCAPE_ATTEMPTS) {
+        // Focus a trap element
+        await page.evaluate(
+          ({ sel }: { sel: string }) => {
+            const el = document.querySelector(sel);
+            if (el instanceof HTMLElement) el.focus();
+          },
+          { sel: representative.selector },
+        );
+
+        const clicked: boolean = await page.evaluate(
+          ({ selectors }: { selectors: string[] }) => {
+            const els = selectors
+              .map((s) => document.querySelector(s))
+              .filter((el): el is Element => el !== null);
+            if (els.length === 0) return false;
+
+            let container: Element | null = els[0] ?? null;
+            while (container && container !== document.body) {
+              const closeBtn = container.querySelector(
+                'button, [role="button"]',
+              );
+              if (closeBtn) {
+                const label =
+                  (closeBtn as HTMLElement).getAttribute('aria-label') ||
+                  (closeBtn as HTMLElement).textContent?.trim() ||
+                  '';
+                if (/close|閉じる|dismiss/i.test(label)) {
+                  (closeBtn as HTMLElement).click();
+                  return true;
+                }
+              }
+              container = container.parentElement;
+            }
+            return false;
+          },
+          { selectors: trapSelectors.slice(0, 3) },
+        );
+
+        if (clicked) {
+          await page.waitForTimeout(KEYBOARD_TRAP_ESCAPE_SETTLE_MS);
+          const afterSel: string = await page.evaluate(() => {
+            const active = document.activeElement;
+            if (
+              !active ||
+              active === document.body ||
+              active === document.documentElement
+            ) {
+              return '(body)';
+            }
+            function getSelector(element: Element): string {
+              const parts: string[] = [];
+              let current: Element | null = element;
+              while (current && current !== document.documentElement) {
+                const tag = current.tagName.toLowerCase();
+                const id = current.id ? `#${CSS.escape(current.id)}` : '';
+                if (id) {
+                  parts.unshift(`${tag}${id}`);
+                  break;
+                }
+                const p: Element | null = current.parentElement;
+                if (p) {
+                  const siblings = [...p.children].filter(
+                    (c) => c.tagName === current!.tagName,
+                  );
+                  const idx = siblings.indexOf(current) + 1;
+                  parts.unshift(
+                    siblings.length > 1 ? `${tag}:nth-of-type(${idx})` : tag,
+                  );
+                } else {
+                  parts.unshift(tag);
+                }
+                current = p;
+              }
+              return parts.join(' > ');
+            }
+            return getSelector(active);
+          });
+          escapeAttempts.closeAffordance =
+            afterSel === '(body)' || !tailSet.has(afterSel);
+        }
+        attemptCount++;
+      }
+
+      // ------------------------------------------------------------------
+      // 5. Check if container is aria-modal dialog
+      // ------------------------------------------------------------------
+      const isAriaModal: boolean = await page.evaluate(
+        ({ selectors }: { selectors: string[] }) => {
+          for (const sel of selectors) {
+            let el: Element | null = document.querySelector(sel);
+            while (el && el !== document.body) {
+              if (
+                el.getAttribute('role') === 'dialog' &&
+                el.getAttribute('aria-modal') === 'true'
+              ) {
+                return true;
+              }
+              el = el.parentElement;
+            }
+          }
+          return false;
+        },
+        { selectors: trapSelectors.slice(0, 3) },
+      );
+
+      // ------------------------------------------------------------------
+      // 6. Classify
+      // ------------------------------------------------------------------
+      const anyEscapeWorks =
+        escapeAttempts.escape ||
+        escapeAttempts.shiftTab ||
+        escapeAttempts.closeAffordance;
+
+      const evidence: KeyboardTrapEvidence = {
+        selector: representative.selector,
+        tag: representative.tag,
+        name: representative.name,
+        html: representative.html,
+        htmlTruncated: representative.htmlTruncated,
+        escapeAttempts,
+        isAriaModal,
+      };
+
+      if (!anyEscapeWorks) {
+        // True trap: no escape works → violation
+        confirmedTraps.push(evidence);
+      } else if (isAriaModal && escapeAttempts.escape) {
+        // Correct modal pattern: role=dialog + aria-modal=true + Escape → pass
+        // Don't push to either bucket
+      } else {
+        // Escape exists but non-standard → needs review
+        needsReview.push(evidence);
+      }
+    }
+
+    // ------------------------------------------------------------------
+    // 7. Assemble result
+    // ------------------------------------------------------------------
+    const details: KeyboardTrapCheckDetails = {
+      totalFocusableElements: count,
+      trapCandidates: isTrapCandidate ? 1 : 0,
+      confirmedTraps,
+      needsReview,
+      screenshotPath: '',
+    };
+
+    const buckets = normalizeKeyboardTrapCheck(details);
+    const result = buildAuditResult({
+      source: 'keyboard-trap-check',
+      url: page.url(),
+      details,
+      buckets,
+    });
+
+    const resolvedPath = saveAuditResult(result, {
+      ...location,
+      defaultFile: DEFAULT_KEYBOARD_TRAP_RESULT_FILE,
+    });
+
+    if (screenshot) {
+      const screenshotPathOut = await takeAuditScreenshot(page, {
+        path: resolveScreenshotPath(
+          resolvedPath,
+          DEFAULT_KEYBOARD_TRAP_SCREENSHOT_FILE,
+        ),
+      });
+      details.screenshotPath = screenshotPathOut;
+    }
+
+    logAuditHeader('Keyboard Trap Check', 'WCAG 2.1.2', page.url());
+    logOutputPaths(
+      resolvedPath,
+      screenshot
+        ? resolveScreenshotPath(resolvedPath, DEFAULT_KEYBOARD_TRAP_SCREENSHOT_FILE)
+        : undefined,
+    );
+
+    return result;
+  } finally {
+    await context.close();
+  }
+}

--- a/packages/a11y-audit/src/playwright/runKeyboardTrapCheck.ts
+++ b/packages/a11y-audit/src/playwright/runKeyboardTrapCheck.ts
@@ -237,7 +237,7 @@ export async function runKeyboardTrapCheck(
           const ariaLabel = (el as HTMLElement).getAttribute('aria-label');
           const name = ariaLabel
             ? ariaLabel
-            : (el as HTMLElement).textContent?.trim().slice(0, 50) ?? '';
+            : ((el as HTMLElement).textContent?.trim().slice(0, 50) ?? '');
 
           const rawHtml = el.outerHTML;
           const htmlTruncated = rawHtml.length > maxLen;
@@ -268,8 +268,7 @@ export async function runKeyboardTrapCheck(
     const needsReview: KeyboardTrapEvidence[] = [];
 
     // Trap candidate: no (body) in tail, and tail doesn't cover all elements
-    const isTrapCandidate =
-      !tailSet.has('(body)') && tailSet.size < count;
+    const isTrapCandidate = !tailSet.has('(body)') && tailSet.size < count;
 
     if (isTrapCandidate) {
       const trapSelectors = [...tailSet];
@@ -536,7 +535,10 @@ export async function runKeyboardTrapCheck(
     logOutputPaths(
       resolvedPath,
       screenshot
-        ? resolveScreenshotPath(resolvedPath, DEFAULT_KEYBOARD_TRAP_SCREENSHOT_FILE)
+        ? resolveScreenshotPath(
+            resolvedPath,
+            DEFAULT_KEYBOARD_TRAP_SCREENSHOT_FILE,
+          )
         : undefined,
     );
 

--- a/packages/a11y-audit/src/schemas/index.ts
+++ b/packages/a11y-audit/src/schemas/index.ts
@@ -65,6 +65,9 @@ export type {
   PauseVerificationResult,
   AutoPlayDetectionDetails,
   AutoPlayDetectionResult,
+  KeyboardTrapEvidence,
+  KeyboardTrapCheckDetails,
+  KeyboardTrapCheckResult,
 } from '../types.js';
 
 /** Minimal JSON Schema object shape (Draft 2020-12 compatible subset). */
@@ -563,6 +566,30 @@ export const AUTO_PLAY_DETECTION_RESULT_SCHEMA: JsonSchema =
     },
   });
 
+export const KEYBOARD_TRAP_CHECK_RESULT_SCHEMA: JsonSchema =
+  buildEnvelopeSchema({
+    id: 'keyboard-trap-check-result',
+    title: 'KeyboardTrapCheckResult',
+    source: 'keyboard-trap-check',
+    details: {
+      type: 'object',
+      required: [
+        'totalFocusableElements',
+        'trapCandidates',
+        'confirmedTraps',
+        'needsReview',
+        'screenshotPath',
+      ],
+      properties: {
+        totalFocusableElements: { type: 'number' },
+        trapCandidates: { type: 'number' },
+        confirmedTraps: { type: 'array', items: { type: 'object' } },
+        needsReview: { type: 'array', items: { type: 'object' } },
+        screenshotPath: { type: 'string' },
+      },
+    },
+  });
+
 /** All result schemas keyed by check id. */
 export const RESULT_SCHEMAS = {
   'axe-audit': AXE_AUDIT_RESULT_SCHEMA,
@@ -575,4 +602,5 @@ export const RESULT_SCHEMAS = {
   'autocomplete-audit': AUTOCOMPLETE_AUDIT_RESULT_SCHEMA,
   'time-limit-detector': TIME_LIMIT_DETECTOR_RESULT_SCHEMA,
   'auto-play-detection': AUTO_PLAY_DETECTION_RESULT_SCHEMA,
+  'keyboard-trap-check': KEYBOARD_TRAP_CHECK_RESULT_SCHEMA,
 } as const;

--- a/packages/a11y-audit/src/test-entries/keyboard-trap-check.ts
+++ b/packages/a11y-audit/src/test-entries/keyboard-trap-check.ts
@@ -1,0 +1,14 @@
+/**
+ * Compatibility test entry for the keyboard trap check (WCAG 2.1.2).
+ *
+ * Thin wrapper around `runKeyboardTrapCheck`. Target URL from `TEST_PAGE`,
+ * output dir from `A11Y_OUTPUT_DIR` (falling back to cwd). This check owns
+ * its browser context (see runKeyboardTrapCheck).
+ */
+
+import { test } from '@playwright/test';
+import { runKeyboardTrapCheck } from '../playwright/runKeyboardTrapCheck.js';
+
+test('keyboard trap check', async ({ browser }) => {
+  await runKeyboardTrapCheck({ browser, screenshot: true });
+});

--- a/packages/a11y-audit/src/types.ts
+++ b/packages/a11y-audit/src/types.ts
@@ -578,7 +578,11 @@ export interface KeyboardTrapEvidence {
   html: string;
   htmlTruncated: boolean;
   /** Escape attempts and their outcomes (used in incomplete failure summaries). */
-  escapeAttempts: { escape: boolean; shiftTab: boolean; closeAffordance: boolean };
+  escapeAttempts: {
+    escape: boolean;
+    shiftTab: boolean;
+    closeAffordance: boolean;
+  };
   /** Whether the trap container has role=dialog and aria-modal=true. */
   isAriaModal: boolean;
 }
@@ -598,4 +602,5 @@ export interface KeyboardTrapCheckDetails {
   screenshotPath: string;
 }
 
-export type KeyboardTrapCheckResult = AuditCheckResult<KeyboardTrapCheckDetails>;
+export type KeyboardTrapCheckResult =
+  AuditCheckResult<KeyboardTrapCheckDetails>;

--- a/packages/a11y-audit/src/types.ts
+++ b/packages/a11y-audit/src/types.ts
@@ -28,7 +28,8 @@ export type CheckSource =
   | 'orientation-check'
   | 'autocomplete-audit'
   | 'time-limit-detector'
-  | 'auto-play-detection';
+  | 'auto-play-detection'
+  | 'keyboard-trap-check';
 
 export type NormalizedImpact = 'critical' | 'serious' | 'moderate' | 'minor';
 
@@ -565,3 +566,36 @@ export interface AutoPlayDetectionDetails {
 
 export type AutoPlayDetectionResult =
   AuditCheckResult<AutoPlayDetectionDetails>;
+
+// =============================================================================
+// Keyboard Trap Check (WCAG 2.1.2)
+// =============================================================================
+
+export interface KeyboardTrapEvidence {
+  selector: string;
+  tag: string;
+  name: string;
+  html: string;
+  htmlTruncated: boolean;
+  /** Escape attempts and their outcomes (used in incomplete failure summaries). */
+  escapeAttempts: { escape: boolean; shiftTab: boolean; closeAffordance: boolean };
+  /** Whether the trap container has role=dialog and aria-modal=true. */
+  isAriaModal: boolean;
+}
+
+export interface KeyboardTrapCheckDetails {
+  totalFocusableElements: number;
+  /** Number of trap candidates detected. */
+  trapCandidates: number;
+  /** Traps from which no escape path worked (→ violation). */
+  confirmedTraps: KeyboardTrapEvidence[];
+  /** Traps that have an escape path but require manual review (→ incomplete). */
+  needsReview: KeyboardTrapEvidence[];
+  /**
+   * Path the screenshot was (or would be) written to. Empty string when
+   * `screenshot` was disabled.
+   */
+  screenshotPath: string;
+}
+
+export type KeyboardTrapCheckResult = AuditCheckResult<KeyboardTrapCheckDetails>;

--- a/packages/a11y-audit/src/utils/axe-format.ts
+++ b/packages/a11y-audit/src/utils/axe-format.ts
@@ -17,6 +17,7 @@ import type {
   CheckSource,
   FocusCheckDetails,
   FocusElementRef,
+  KeyboardTrapCheckDetails,
   NormalizedImpact,
   NormalizedNode,
   NormalizedRuleResult,
@@ -524,6 +525,47 @@ export function normalizeAutoPlayDetection(
     );
   }
   bucketize(buckets, 'auto-play', nodes, true);
+
+  return buckets;
+}
+
+// =============================================================================
+// Keyboard Trap Check normalization (WCAG 2.1.2)
+// =============================================================================
+
+export function normalizeKeyboardTrapCheck(
+  details: KeyboardTrapCheckDetails,
+): NormalizedBuckets {
+  const buckets = emptyBuckets();
+  const applicable = details.totalFocusableElements > 0;
+  buckets.checkedNodes = details.totalFocusableElements;
+
+  bucketize(
+    buckets,
+    'no-keyboard-trap',
+    details.confirmedTraps.map((t) =>
+      pageNode(
+        `Keyboard focus is trapped in <${t.tag.toLowerCase()}> "${t.name}" ` +
+          `(${t.selector}). None of Escape / Shift+Tab / a close control moved ` +
+          `focus out. Keyboard users cannot leave this region.`,
+      ),
+    ),
+    applicable,
+  );
+
+  bucketize(
+    buckets,
+    'keyboard-trap-needs-review',
+    details.needsReview.map((t) =>
+      pageNode(
+        `Focus appears confined to <${t.tag.toLowerCase()}> "${t.name}" ` +
+          `(${t.selector}); it can be left via ` +
+          `${[t.escapeAttempts.escape && 'Escape', t.escapeAttempts.shiftTab && 'Shift+Tab', t.escapeAttempts.closeAffordance && 'a close control'].filter(Boolean).join(', ')}. ` +
+          `Verify the escape method is documented/discoverable (WCAG 2.1.2 exception).`,
+      ),
+    ),
+    applicable,
+  );
 
   return buckets;
 }

--- a/packages/a11y-audit/src/utils/rule-registry.ts
+++ b/packages/a11y-audit/src/utils/rule-registry.ts
@@ -258,6 +258,33 @@ export const RULES = {
     // pixel diffing cannot identify the content type or audio.
     classification: 'incomplete',
   },
+
+  // --- keyboard-trap-check ---
+  'no-keyboard-trap': {
+    id: 'a11y-skills/no-keyboard-trap',
+    sc: ['2.1.2'],
+    tags: ['a11y-skills', 'wcag2a', 'wcag212'],
+    impact: 'critical',
+    scope: 'page',
+    description: 'Ensure keyboard focus can be moved away from all components',
+    help: 'Keyboard users must be able to navigate away from any focused component',
+    helpUrl: `${UNDERSTANDING}/no-keyboard-trap.html`,
+    // focus confinement with no working exit is directly observed; no exception applies.
+    classification: 'violation',
+  },
+  'keyboard-trap-needs-review': {
+    id: 'a11y-skills/keyboard-trap-needs-review',
+    sc: ['2.1.2'],
+    tags: ['a11y-skills', 'wcag2a', 'wcag212'],
+    impact: 'critical',
+    scope: 'page',
+    description:
+      'Focus appears confined; verify whether the escape path is documented or discoverable',
+    help: 'Verify that users can escape focus-confined areas via documented keyboard methods',
+    helpUrl: `${UNDERSTANDING}/no-keyboard-trap.html`,
+    // 2.1.2 allows non-standard exit if the user is advised; that judgment is manual.
+    classification: 'incomplete',
+  },
 } as const satisfies Record<string, RuleMeta>;
 
 export type RuleKey = keyof typeof RULES;

--- a/packages/a11y-audit/test/fixtures/keyboard-trap-modal.html
+++ b/packages/a11y-audit/test/fixtures/keyboard-trap-modal.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Keyboard Trap Fixture - Proper Modal</title>
+    <style>
+      #modal-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.5);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      #modal {
+        background: white;
+        padding: 2rem;
+        border-radius: 8px;
+        min-width: 300px;
+      }
+      #main-content {
+        padding: 2rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="main-content">
+      <h1>Page with Proper Modal</h1>
+      <p>The modal is open on page load.</p>
+    </div>
+
+    <!-- Proper modal: role=dialog + aria-modal=true + Escape closes it -->
+    <div id="modal-backdrop">
+      <div
+        id="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+      >
+        <h2 id="modal-title">Confirmation Dialog</h2>
+        <p>Please confirm your action.</p>
+        <button id="modal-confirm">Confirm</button>
+        <button id="modal-cancel" aria-label="Close">Cancel</button>
+      </div>
+    </div>
+
+    <script>
+      const backdrop = document.getElementById('modal-backdrop');
+      const modalConfirm = document.getElementById('modal-confirm');
+
+      function closeModal() {
+        backdrop.style.display = 'none';
+      }
+
+      // Escape key closes the modal (WCAG 2.1.2 compliant exit)
+      document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape' && backdrop.style.display !== 'none') {
+          closeModal();
+        }
+      });
+
+      document.getElementById('modal-cancel').addEventListener('click', closeModal);
+      modalConfirm.addEventListener('click', closeModal);
+
+      // Keep focus inside modal while it is open (proper focus trap)
+      document.addEventListener('focusin', function (e) {
+        if (
+          backdrop.style.display !== 'none' &&
+          !backdrop.contains(e.target)
+        ) {
+          modalConfirm.focus();
+        }
+      });
+
+      // Open modal on load
+      window.addEventListener('load', function () {
+        modalConfirm.focus();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/a11y-audit/test/fixtures/keyboard-trap-modal.html
+++ b/packages/a11y-audit/test/fixtures/keyboard-trap-modal.html
@@ -59,15 +59,14 @@
         }
       });
 
-      document.getElementById('modal-cancel').addEventListener('click', closeModal);
+      document
+        .getElementById('modal-cancel')
+        .addEventListener('click', closeModal);
       modalConfirm.addEventListener('click', closeModal);
 
       // Keep focus inside modal while it is open (proper focus trap)
       document.addEventListener('focusin', function (e) {
-        if (
-          backdrop.style.display !== 'none' &&
-          !backdrop.contains(e.target)
-        ) {
+        if (backdrop.style.display !== 'none' && !backdrop.contains(e.target)) {
           modalConfirm.focus();
         }
       });

--- a/packages/a11y-audit/test/fixtures/keyboard-trap-none.html
+++ b/packages/a11y-audit/test/fixtures/keyboard-trap-none.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Keyboard Trap Fixture - No Trap</title>
+  </head>
+  <body>
+    <h1>No Keyboard Trap</h1>
+    <p>
+      This page has normal focusable elements that can be tabbed through freely.
+    </p>
+    <button>Button One</button>
+    <button>Button Two</button>
+    <input type="text" aria-label="Name" />
+    <a href="#">Link One</a>
+    <a href="#">Link Two</a>
+  </body>
+</html>

--- a/packages/a11y-audit/test/fixtures/keyboard-trap-true.html
+++ b/packages/a11y-audit/test/fixtures/keyboard-trap-true.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Keyboard Trap Fixture - True Trap</title>
+  </head>
+  <body>
+    <h1>Keyboard Trap Demo</h1>
+    <p>Normal content before the trap.</p>
+
+    <!-- Keyboard trap: focus is re-assigned to trap-a whenever it leaves the trap region. -->
+    <div id="trap-region">
+      <button id="trap-a">Trap Button A</button>
+      <button id="trap-b">Trap Button B</button>
+    </div>
+
+    <a href="#">Link after trap</a>
+
+    <script>
+      // Focusout trap: whenever focus leaves #trap-region, force it back in.
+      // No Escape key handler is installed, so there is no way out.
+      const trapA = document.getElementById('trap-a');
+      const trapB = document.getElementById('trap-b');
+      const region = document.getElementById('trap-region');
+
+      document.addEventListener('focusin', function (e) {
+        if (!region.contains(e.target)) {
+          // Refocus the first trap element
+          e.preventDefault();
+          trapA.focus();
+        }
+      });
+
+      // Set initial focus into the trap on load
+      window.addEventListener('load', function () {
+        trapA.focus();
+      });
+    </script>
+  </body>
+</html>

--- a/packages/a11y-audit/test/schema-validation.spec.ts
+++ b/packages/a11y-audit/test/schema-validation.spec.ts
@@ -10,11 +10,13 @@ import {
   buildAuditResult,
   normalizeAxeResults,
   normalizeFocusCheck,
+  normalizeKeyboardTrapCheck,
   normalizeReflowCheck,
   normalizeTargetSizeCheck,
 } from '../dist/index.js';
 import type {
   FocusCheckDetails,
+  KeyboardTrapCheckDetails,
   ReflowCheckDetails,
   TargetSizeCheckDetails,
 } from '../dist/index.js';
@@ -168,6 +170,33 @@ test('target-size-check envelope validates against its schema', () => {
     buckets: normalizeTargetSizeCheck(details),
   });
   expectValid('target-size-check', result);
+});
+
+test('keyboard-trap-check envelope validates against its schema', () => {
+  const details: KeyboardTrapCheckDetails = {
+    totalFocusableElements: 2,
+    trapCandidates: 1,
+    confirmedTraps: [
+      {
+        selector: '#trap-a',
+        tag: 'BUTTON',
+        name: 'Trap Button A',
+        html: '<button id="trap-a">Trap Button A</button>',
+        htmlTruncated: false,
+        escapeAttempts: { escape: false, shiftTab: false, closeAffordance: false },
+        isAriaModal: false,
+      },
+    ],
+    needsReview: [],
+    screenshotPath: '',
+  };
+  const result = buildAuditResult({
+    source: 'keyboard-trap-check',
+    url: 'about:blank',
+    details,
+    buckets: normalizeKeyboardTrapCheck(details),
+  });
+  expectValid('keyboard-trap-check', result);
 });
 
 test('the pre-0.3.0 flat result shape is rejected', () => {

--- a/packages/a11y-audit/test/schema-validation.spec.ts
+++ b/packages/a11y-audit/test/schema-validation.spec.ts
@@ -183,7 +183,11 @@ test('keyboard-trap-check envelope validates against its schema', () => {
         name: 'Trap Button A',
         html: '<button id="trap-a">Trap Button A</button>',
         htmlTruncated: false,
-        escapeAttempts: { escape: false, shiftTab: false, closeAffordance: false },
+        escapeAttempts: {
+          escape: false,
+          shiftTab: false,
+          closeAffordance: false,
+        },
         isAriaModal: false,
       },
     ],

--- a/packages/a11y-audit/test/smoke.spec.ts
+++ b/packages/a11y-audit/test/smoke.spec.ts
@@ -150,7 +150,9 @@ test('runKeyboardTrapCheck detects true keyboard trap as violation', async ({
 
   expect(result.source).toBe('keyboard-trap-check');
   expect(result.details.totalFocusableElements).toBeGreaterThan(0);
-  expect(result.summary.checkedNodes).toBe(result.details.totalFocusableElements);
+  expect(result.summary.checkedNodes).toBe(
+    result.details.totalFocusableElements,
+  );
   expect(
     result.violations.some((r) => r.id === 'a11y-skills/no-keyboard-trap'),
   ).toBe(true);

--- a/packages/a11y-audit/test/smoke.spec.ts
+++ b/packages/a11y-audit/test/smoke.spec.ts
@@ -6,13 +6,20 @@
  * published artifact. Each fixture is crafted to trigger the relevant check.
  */
 
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { test, expect } from '@playwright/test';
 import {
   runAxeAudit,
   runReflowCheck,
   runTargetSizeCheck,
   runFocusIndicatorCheck,
+  runKeyboardTrapCheck,
 } from '../dist/playwright/index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtureUrl = (name: string) =>
+  `file://${path.join(__dirname, 'fixtures', name)}`;
 
 const AXE_FIXTURE = `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><title>axe fixture</title></head>
@@ -130,4 +137,50 @@ test('runFocusIndicatorCheck flags missing focus indicator as incomplete', async
   expect(focusVisible).toBeDefined();
   expect(focusVisible!.nodes[0].target[0]).toContain('#nofocus');
   expect(focusVisible!.nodes[0].html).toContain('button');
+});
+
+test('runKeyboardTrapCheck detects true keyboard trap as violation', async ({
+  browser,
+}, testInfo) => {
+  const result = await runKeyboardTrapCheck({
+    browser,
+    targetUrl: fixtureUrl('keyboard-trap-true.html'),
+    outputDir: testInfo.outputDir,
+  });
+
+  expect(result.source).toBe('keyboard-trap-check');
+  expect(result.details.totalFocusableElements).toBeGreaterThan(0);
+  expect(result.summary.checkedNodes).toBe(result.details.totalFocusableElements);
+  expect(
+    result.violations.some((r) => r.id === 'a11y-skills/no-keyboard-trap'),
+  ).toBe(true);
+});
+
+test('runKeyboardTrapCheck passes for a proper aria-modal dialog', async ({
+  browser,
+}, testInfo) => {
+  const result = await runKeyboardTrapCheck({
+    browser,
+    targetUrl: fixtureUrl('keyboard-trap-modal.html'),
+    outputDir: testInfo.outputDir,
+  });
+
+  expect(result.source).toBe('keyboard-trap-check');
+  expect(result.violations).toHaveLength(0);
+  expect(result.incomplete).toHaveLength(0);
+});
+
+test('runKeyboardTrapCheck passes for a page with no keyboard trap', async ({
+  browser,
+}, testInfo) => {
+  const result = await runKeyboardTrapCheck({
+    browser,
+    targetUrl: fixtureUrl('keyboard-trap-none.html'),
+    outputDir: testInfo.outputDir,
+  });
+
+  expect(result.source).toBe('keyboard-trap-check');
+  expect(result.violations).toHaveLength(0);
+  expect(result.incomplete).toHaveLength(0);
+  expect(result.details.totalFocusableElements).toBeGreaterThan(0);
 });

--- a/skills/auditing-wcag/SKILL.ja.md
+++ b/skills/auditing-wcag/SKILL.ja.md
@@ -119,5 +119,6 @@ npx -y @a11y-skills/audit --url "https://example.com" --output-dir ./results
 | `auto-play-detection` | 1.4.2, 2.2.2 | 自動再生コンテンツの検出 |
 | `focus-indicator-check` | 2.4.7 | フォーカスインジケーターの視認性 |
 | `target-size-check` | 2.5.5, 2.5.8 | ターゲットサイズの測定 |
+| `keyboard-trap-check` | 2.1.2 | キーボードトラップ検出 |
 
 詳細は [`@a11y-skills/audit` README](https://www.npmjs.com/package/@a11y-skills/audit) を参照してください。

--- a/skills/auditing-wcag/SKILL.md
+++ b/skills/auditing-wcag/SKILL.md
@@ -119,5 +119,6 @@ npx -y @a11y-skills/audit --url "https://example.com" --output-dir ./results
 | `auto-play-detection` | 1.4.2, 2.2.2 | Auto-play content detection |
 | `focus-indicator-check` | 2.4.7 | Focus indicator visibility |
 | `target-size-check` | 2.5.5, 2.5.8 | Target size measurement |
+| `keyboard-trap-check` | 2.1.2 | Keyboard trap detection |
 
 See the [`@a11y-skills/audit` README](https://www.npmjs.com/package/@a11y-skills/audit) for detailed documentation.


### PR DESCRIPTION
## 概要

設計スパイク（Plan 006、Go 判定）の実装です。`@a11y-skills/audit` に **11 個目のチェック `keyboard-trap-check`**（WCAG 2.1.2 No Keyboard Trap）を追加します。axe-core に自動ルールが無い領域で、キーボードユーザーがページ操作を完全に失う致命的失敗を検出します。

```sh
npx -y @a11y-skills/audit --url <url> --checks keyboard-trap-check
```

## アルゴリズム（スパイク設計からの補正込み）

ページをフルに Tab ウォークし、フォーカスが部分集合に閉じ込められる領域を検出 → 3 つの脱出パス（Escape / Shift+Tab / 可視クローズ要素クリック）を試行して分類します。

| 分類 | 条件 | ルール |
|---|---|---|
| violation | どの脱出パスも機能しない真のトラップ | `a11y-skills/no-keyboard-trap`（critical） |
| incomplete | 脱出可能だが非慣用的（`role=dialog`+`aria-modal=true` でない等） | `a11y-skills/keyboard-trap-needs-review`（要人手確認） |
| pass | `role=dialog`+`aria-modal=true` + Escape で閉じる正しいモーダル | — |

**設計の欠陥を 1 点補正**: スパイク設計の固定ウィンドウ `KEYBOARD_TRAP_WINDOW=10` はフォーカス可能要素数 > 10 のページで誤検知します。健全なページでも末尾 11 ステップに全要素が現れないためです。これを **`count + 1`（フルサイクル 1 周分）ウィンドウ**に置き換え、要素数非依存で堅牢にしました。ウォーク長も終盤トラップを取りこぼさないよう `2*count + slack`（上限付き）に。

## 変更内容（+994 行 / 19 ファイル）

- **新規**: `src/playwright/runKeyboardTrapCheck.ts`(runner、browser 所有モデル)、test-entry ラッパー、フィクスチャ 3 種
- **統合**: constants(6)、types(`CheckSource` + 3 型)、rule-registry(2 エントリ)、axe-format(`normalizeKeyboardTrapCheck`、page-scope)、schema、CLI registry(`kind: 'browser'`)、exports
- **ドキュメント**: SKILL.md / SKILL.ja.md のチェック表に 1 行(EN/JA)、CHANGELOG 0.5.0

## 検証済み

- 3 フィクスチャ: true→violation / modal→pass / none→pass（期待どおり）
- **CI 安全性**: `file://`→`waitUntil:'load'` 実装。`--checks all` を cli-smoke.html に実行 → keyboard-trap DONE・**Errors 0**・exit 1（既存 2 スモークが新チェックを自動的に通すため必須）
- テスト 26→30 green（smoke 3 + schema 1 追加）、lint / format green

## 既知の制限（runner の docstring に明記）

Shadow DOM 内・iframe 内・`inert` 動的付与のトラップは検出対象外。真トラップ（violation）はレアで、`incomplete`（人手レビューの絞り込み）が主価値という設計の位置づけです。

## マージ後

新機能なので **0.5.0**（minor）としてリリースします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
