### PR TITLE
chore(release): @a11y-skills/audit 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1773,7 +1773,7 @@
     },
     "packages/a11y-audit": {
       "name": "@a11y-skills/audit",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "bin": {
         "a11y-audit": "dist/cli.js"

--- a/packages/a11y-audit/package.json
+++ b/packages/a11y-audit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@a11y-skills/audit",
-  "version": "0.4.1",
-  "description": "Playwright + axe-core based WCAG 2.2 accessibility audit functions (axe, focus indicator, reflow, target size, text spacing, zoom, orientation, autocomplete, time limit, auto-play).",
+  "version": "0.5.0",
+  "description": "Playwright + axe-core based WCAG 2.2 accessibility audit functions (axe, focus indicator, keyboard trap, reflow, target size, text spacing, zoom, orientation, autocomplete, time limit, auto-play).",
   "type": "module",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## 概要

`@a11y-skills/audit` を **0.5.0**（minor）にバンプします。PR #39 で追加した 11 個目のチェック `keyboard-trap-check`（WCAG 2.1.2）のリリースです。CHANGELOG の 0.5.0 エントリは #39 で追加済み。

## 変更内容

- `package.json`: `0.4.1` → `0.5.0`、description に keyboard trap を追記
- `package-lock.json`: バージョン同期

## マージ後

タグ `a11y-audit-v0.5.0` を push → release.yml が npm に publish。bump-wrapper ジョブは 2.10.0 で引退済みのため、close/reopen の儀式は不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
